### PR TITLE
Hk managed dependency

### DIFF
--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -110,11 +110,9 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Housekeeping -->
     <dependency>
       <groupId>com.hotels</groupId>
       <artifactId>housekeeping</artifactId>
-      <version>1.0.0</version>
     </dependency>
 
     <!-- YAML -->

--- a/circus-train-housekeeping/pom.xml
+++ b/circus-train-housekeeping/pom.xml
@@ -20,11 +20,9 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Housekeeping -->
     <dependency>
       <groupId>com.hotels</groupId>
       <artifactId>housekeeping</artifactId>
-      <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -64,6 +65,13 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>com.hotels</groupId>
+        <artifactId>housekeeping</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+      </dependency>
+      
       <dependency>
         <groupId>io.spring.platform</groupId>
         <artifactId>platform-bom</artifactId>
@@ -208,7 +216,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-        <dependency>
+      <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>com.hotels</groupId>
         <artifactId>housekeeping</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.0</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
This moves HK to a managed dependency in the parent pom so we only need to change the version number in one place.