### PR TITLE
Remove stash references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+### Changed
+* Fixed references to README.md in command line runner help messages to point to correct GitHub locations.
 
 # 11.0.0 - 2018-01-16
 ### Changed

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrainHelp.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrainHelp.java
@@ -57,7 +57,7 @@ class CircusTrainHelp {
         .append(System.lineSeparator())
         .append(TAB)
         .append("For more information and help please refer to ")
-        .append("https://stash/projects/HDW/repos/circus-train/browse/README.md");
+        .append("https://github.com/HotelsDotCom/circus-train/blob/master/README.md");
     return help.toString();
   }
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainHelpTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainHelpTest.java
@@ -33,7 +33,7 @@ public class CircusTrainHelpTest {
         + "\tError message 1\n"
         + "\tError message 2\n"
         + "Configuration file help:\n"
-        + "\tFor more information and help please refer to https://stash/projects/HDW/repos/circus-train/browse/README.md";
+        + "\tFor more information and help please refer to https://github.com/HotelsDotCom/circus-train/blob/master/README.md";
     List<ObjectError> errors = Arrays.asList(new ObjectError("object.1", "Error message 1"),
         new ObjectError("object.2", "Error message 2"));
     String help = new CircusTrainHelp(errors).toString();

--- a/circus-train-tool-parent/circus-train-filter-tool/src/main/java/com/hotels/bdp/circustrain/tool/filter/FilterToolHelp.java
+++ b/circus-train-tool-parent/circus-train-filter-tool/src/main/java/com/hotels/bdp/circustrain/tool/filter/FilterToolHelp.java
@@ -57,8 +57,7 @@ class FilterToolHelp {
         .append(System.lineSeparator())
         .append(TAB)
         .append("For more information and help please refer to ")
-        .append(
-            "https://stash/projects/HDW/repos/circus-train/circus-train-tool/circus-train-filter-tool/browse/README.md");
+        .append("https://github.com/HotelsDotCom/circus-train/tree/master/circus-train-tool-parent");
     return help.toString();
   }
 

--- a/circus-train-tool-parent/circus-train-vacuum-tool/src/main/java/com/hotels/bdp/circustrain/tool/vacuum/VacuumToolHelp.java
+++ b/circus-train-tool-parent/circus-train-vacuum-tool/src/main/java/com/hotels/bdp/circustrain/tool/vacuum/VacuumToolHelp.java
@@ -57,8 +57,7 @@ class VacuumToolHelp {
         .append(System.lineSeparator())
         .append(TAB)
         .append("For more information and help please refer to ")
-        .append(
-            "https://stash/projects/HDW/repos/circus-train/circus-train-tool/circus-train-vacuum-tool/browse/README.md");
+        .append("https://github.com/HotelsDotCom/circus-train/tree/master/circus-train-tool-parent");
     return help.toString();
   }
 }


### PR DESCRIPTION
A very small PR to fix the help messages, I noticed when testing on EMR that the "usage" messages were pointing to the pre-open-source locations for the README.md.