### PR TITLE
Guava version conflicts, managed dependencies for Google Cloud

### DIFF
--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeCopierListener.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeCopierListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeLocomotiveListener.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeLocomotiveListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeTableReplicationListener.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/event/CompositeTableReplicationListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-gcp/pom.xml
+++ b/circus-train-gcp/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -47,19 +48,21 @@
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
-      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.22.0</version>
     </dependency>
- 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+
     <!-- Hadoop -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -66,19 +67,30 @@
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>com.hotels</groupId>
         <artifactId>housekeeping</artifactId>
         <version>${housekeeping.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>0.34.0-alpha</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.spring.platform</groupId>
         <artifactId>platform-bom</artifactId>
         <version>${spring-platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -257,22 +269,31 @@
             <excludes>
               <exclude>src/main/java/com/hotels/bdp/circustrain/comparator/comparator/PropertyComparator.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/validation/constraints/TunnelRoute.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/validation/constraintvalidators/TunnelRouteValidator.java</exclude>
+              <exclude>
+                src/main/java/com/hotels/bdp/circustrain/validation/constraintvalidators/TunnelRouteValidator.java
+              </exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/command/RetriableCommand.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/io/BytesFormatter.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/io/ThrottledInputStream.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PositiveLong.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PositiveNonZeroInteger.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PositiveNonZeroLong.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputChunk.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputFormat.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicRecordReader.java</exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PositiveNonZeroInteger.java
+              </exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PositiveNonZeroLong.java
+              </exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputChunk.java
+              </exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputFormat.java
+              </exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicRecordReader.java
+              </exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/CopyCommitter.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/CopyMapper.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/CopyOutputFormat.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/Counter.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/RetriableFileCopyCommand.java</exclude>
-              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/UniformSizeInputFormat.java</exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/RetriableFileCopyCommand.java
+              </exclude>
+              <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/UniformSizeInputFormat.java
+              </exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/util/ConfigurationUtil.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/util/IoUtil.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/util/PathUtil.java</exclude>
@@ -282,9 +303,12 @@
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpConstants.java</exclude>
               <exclude>src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/SimpleCopyListing.java</exclude>
               <exclude>src/main/resources/s3mapreducecp-default.xml</exclude>
-              <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/command/RetriableCommandTest.java</exclude>
+              <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/command/RetriableCommandTest.java
+              </exclude>
               <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/io/ThrottledInputStreamTest.java</exclude>
-              <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputFormatTest.java</exclude>
+              <exclude>
+                src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/lib/DynamicInputFormatTest.java
+              </exclude>
               <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/ConfigurationUtilTest.java</exclude>
               <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/IoUtilTest.java</exclude>
               <exclude>src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/PathUtilTest.java</exclude>


### PR DESCRIPTION
I ran into some dependency problems in Google Cloud using latest version of Circus Train, GCP dependencies require Guava version >= 18.0, Spring dependency management was pulling in Guava 17.0 