### PR TITLE
Issue 49: S3-S3 Copier Hive Diff Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# TBD
+# 11.3.1 - 2018-03-21
 ### Changed
 * Clearer replica-check exception message. See [#47](https://github.com/HotelsDotCom/circus-train/issues/47).
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Changed
 * Clearer replica-check exception message. See [#47](https://github.com/HotelsDotCom/circus-train/issues/47).
 ### Fixed
-* S3-S3 Hive Diff calculating incorrect checksum on folders
+* S3-S3 Hive Diff calculating incorrect checksum on folders. See [#49](https://github.com/HotelsDotCom/circus-train/issues/49).
 
 # 11.3.0 - 2018-02-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # TBD
 ### Changed
 * Clearer replica-check exception message. See [#47](https://github.com/HotelsDotCom/circus-train/issues/47).
+### Fixed
+* S3-S3 Hive Diff calculating incorrect checksum on folders
 
 # 11.3.0 - 2018-02-27
 ### Changed

--- a/circus-train-comparator/src/main/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadata.java
+++ b/circus-train-comparator/src/main/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadata.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 

--- a/circus-train-comparator/src/main/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadata.java
+++ b/circus-train-comparator/src/main/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 
@@ -50,16 +52,19 @@ public class PathToPathMetadata implements Function<Path, PathMetadata> {
         checksum = fs.getFileChecksum(location);
       }
 
+      long modificationTime = 0;
       List<PathMetadata> childPathDescriptors = new ArrayList<>();
+
       if (fileStatus.isDirectory()) {
         FileStatus[] childStatuses = fs.listStatus(location);
         for (FileStatus childStatus : childStatuses) {
           childPathDescriptors.add(apply(childStatus.getPath()));
         }
+      } else {
+        modificationTime = fileStatus.getModificationTime();
       }
 
-      return new PathMetadata(location, fileStatus.getModificationTime(), checksum, childPathDescriptors);
-
+      return new PathMetadata(location, modificationTime, checksum, childPathDescriptors);
     } catch (IOException e) {
       throw new CircusTrainException("Unable to compute digest for location " + location.toString(), e);
     }

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -66,7 +65,7 @@ public class PathToPathMetadataIntegrationTest {
     Path path = new Path(baseDir.toURI());
     PathMetadata metadata = function.apply(path);
 
-    assertThat(metadata.getLastModifiedTimestamp(), not(baseDir.lastModified()));
+    assertThat(metadata.getLastModifiedTimestamp(), is(0L));
     assertThat(metadata.getLocation(), is(baseDir.toURI().toString()));
     assertThat(metadata.getChecksumAlgorithmName(), is(nullValue()));
     assertThat(metadata.getChecksumLength(), is(0));

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -65,8 +66,8 @@ public class PathToPathMetadataIntegrationTest {
     Path path = new Path(baseDir.toURI());
     PathMetadata metadata = function.apply(path);
 
+    assertThat(metadata.getLastModifiedTimestamp(), not(baseDir.lastModified()));
     assertThat(metadata.getLocation(), is(baseDir.toURI().toString()));
-    assertThat(metadata.getLastModifiedTimestamp(), is(baseDir.lastModified()));
     assertThat(metadata.getChecksumAlgorithmName(), is(nullValue()));
     assertThat(metadata.getChecksumLength(), is(0));
     assertThat(metadata.getChecksum(), is(nullValue()));

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ public class PathToPathMetadataTest {
 
   private static final String DIR_PATH = "file:/abc";
   private static final String FILE_PATH = DIR_PATH + "/child.dat";
-  private static final long LAST_MODIFIED_DIR = 0;
-  private static final long LAST_MODIFIED_FILE = 999999999999L;
+  private static final long LAST_MODIFIED = 123456789L;
+  private static final long LAST_MODIFIED_CHILD = 999999999999L;
   private static final String CHECKSUM_ALGORITHM = "CHECKSUM_ALGORITHM";
   private static final int CHECKSUM_LENGTH = 64;
   private static final byte[] CHECKSUM_BYTES = new byte[] { 1, 2, 3 };
@@ -64,7 +64,7 @@ public class PathToPathMetadataTest {
     when(path.getFileSystem(any(Configuration.class))).thenReturn(fs);
 
     when(fileStatus.getPath()).thenReturn(path);
-    when(fileStatus.getModificationTime()).thenReturn(LAST_MODIFIED_DIR);
+    when(fileStatus.getModificationTime()).thenReturn(LAST_MODIFIED);
     when(fs.getFileStatus(path)).thenReturn(fileStatus);
 
     when(fileChecksum.getAlgorithmName()).thenReturn(CHECKSUM_ALGORITHM);
@@ -83,7 +83,7 @@ public class PathToPathMetadataTest {
     PathMetadata metadata = function.apply(path);
 
     assertThat(metadata.getLocation(), is(DIR_PATH));
-    assertThat(metadata.getLastModifiedTimestamp(), is(LAST_MODIFIED_DIR));
+    assertThat(metadata.getLastModifiedTimestamp(), is(LAST_MODIFIED));
     assertThat(metadata.getChecksumAlgorithmName(), is(CHECKSUM_ALGORITHM));
     assertThat(metadata.getChecksumLength(), is(CHECKSUM_LENGTH));
     assertThat(metadata.getChecksum(), is(CHECKSUM_BYTES));
@@ -102,7 +102,7 @@ public class PathToPathMetadataTest {
 
     FileStatus childStatus = mock(FileStatus.class);
     when(childStatus.getPath()).thenReturn(childPath);
-    when(childStatus.getModificationTime()).thenReturn(LAST_MODIFIED_FILE);
+    when(childStatus.getModificationTime()).thenReturn(LAST_MODIFIED_CHILD);
     when(childStatus.isFile()).thenReturn(true);
     when(childStatus.isDirectory()).thenReturn(false);
     when(fs.getFileStatus(childPath)).thenReturn(childStatus);
@@ -114,7 +114,7 @@ public class PathToPathMetadataTest {
     PathMetadata metadata = function.apply(path);
 
     assertThat(metadata.getLocation(), is(DIR_PATH));
-    assertThat(metadata.getLastModifiedTimestamp(), is(LAST_MODIFIED_DIR));
+    assertThat(metadata.getLastModifiedTimestamp(), is(0L));
     assertThat(metadata.getChecksumAlgorithmName(), is(nullValue()));
     assertThat(metadata.getChecksumLength(), is(0));
     assertThat(metadata.getChecksum(), is(nullValue()));
@@ -124,7 +124,7 @@ public class PathToPathMetadataTest {
 
     PathMetadata childMetadata = metadata.getChildrenMetadata().get(0);
     assertThat(childMetadata.getLocation(), is(FILE_PATH));
-    assertThat(childMetadata.getLastModifiedTimestamp(), is(LAST_MODIFIED_FILE));
+    assertThat(childMetadata.getLastModifiedTimestamp(), is(LAST_MODIFIED_CHILD));
     assertThat(childMetadata.getChecksumAlgorithmName(), is(CHECKSUM_ALGORITHM));
     assertThat(childMetadata.getChecksumLength(), is(CHECKSUM_LENGTH));
     assertThat(childMetadata.getChecksum(), is(CHECKSUM_BYTES));

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
@@ -38,7 +38,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.hotels.bdp.circustrain.comparator.hive.functions.PathToPathMetadata;
 import com.hotels.bdp.circustrain.comparator.hive.wrappers.PathMetadata;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,7 +45,7 @@ public class PathToPathMetadataTest {
 
   private static final String DIR_PATH = "file:/abc";
   private static final String FILE_PATH = DIR_PATH + "/child.dat";
-  private static final long LAST_MODIFIED_DIR = 123456789L;
+  private static final long LAST_MODIFIED_DIR = 0;
   private static final long LAST_MODIFIED_FILE = 999999999999L;
   private static final String CHECKSUM_ALGORITHM = "CHECKSUM_ALGORITHM";
   private static final int CHECKSUM_LENGTH = 64;


### PR DESCRIPTION
S3 - S3 copying with generate-partition-filter set to true copies all of the tables partitions every time when it should't.

This occurred cause we were creating checksums which depended on the last modified date of a directory, however in S3 the Hadoop api will return the current time rather than a meaningful value.