### PR TITLE
Upgraded jackson.version to 2.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### [TBD] - TBD
 ### Changed
+* Upgraded `jackson.version` to 2.9.7 (was 2.6.6), `aws-jdk.version` to 1.11.431 (was 1.11.126) and `httpcomponents.httpclient.version` to 4.5.5 (was 4.5.2). See [#91](https://github.com/HotelsDotCom/circus-train/issues/91).
 * Refactored general metastore tunnelling code to leverage hcommon-hive-metastore libraries. See [#85](https://github.com/HotelsDotCom/circus-train/issues/85).
 * Refactored the remaining code in `core.metastore` from `circus-train-core` to leverage hcommon-hive-metastore libraries.
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
     <spring-platform.version>2.0.8.RELEASE</spring-platform.version>
     <!-- BEGIN: AWS jdk version + dependencies -->
-    <aws-jdk.version>1.11.126</aws-jdk.version>
-    <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
-    <jackson.version>2.6.6</jackson.version>
+    <aws-jdk.version>1.11.431</aws-jdk.version>
+    <httpcomponents.httpclient.version>4.5.5</httpcomponents.httpclient.version>
+    <jackson.version>2.9.7</jackson.version>
     <!-- END: AWS jdk version + dependencies -->
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.2</hive.version>
@@ -149,12 +149,17 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
+        <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes #91 

I upgraded the AWS Java SDK version while I was at it to see if that would work better with a newer version of Jackson but it didn't. The key was adding jackson-annotations and versioning it, without this there was a version clash resulting in a missing class. I figured it was worth keeping the AWS Java SDK upgrade anyway.