### PR TITLE
Add `copier-options.canned-acl` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## TBD
 ### Added
 * Added replication-strategy configuration that can be used to support propagating deletes (drop table/partition operations). See [README.md](https://github.com/HotelsDotCom/circus-train#replication-strategy) for more details.
+* Ability to specify an S3 canned ACL via `copier-options.canned-acl`. See [#99](https://github.com/HotelsDotCom/circus-train/issues/99).
 
 ## 13.1.0 - 2018-12-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ If data is being replicated from HDFS to S3 then Circus Train will use a customi
 | `copier-options.upload-retry-count`|No|Maximum number of upload retries. Defaults to `3`|
 | `copier-options.upload-retry-delay-ms`|No|Milliseconds between upload retries. The actual delay will be computed as `delay = attempt * copier-options.upload-retry-delay-ms` where `attempt` is the current retry number. Defaults to `300` ms.|
 | `copier-options.upload-buffer-size`|No|Size of the buffer used to upload the stream of data. If the value is `0` the upload will use the value of the HDFS property `io.file.buffer.size` to configure the buffer. Defaults to `0`|
-|`copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
+| `copier-options.canned-acl`|No|AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL.|
+| `copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
 
 ##### S3 to S3 copier options
 If data is being replicated from S3 to S3 then Circus Train will use the AWS S3 API to copy data between S3 buckets. Using the AWS provided APIs no data needs to be downloaded or uploaded to the machine on which Circus Train is running but is copied by AWS internal infrastructure and stays in the AWS network boundaries. Assuming the correct bucket policies are in place cross region and cross account replication is supported. We are using the [TransferManager](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/transfer/TransferManager.html) to do the copying and we expose its options via copier-options see the table below. Given the source and target buckets Circus-Train will try to infer the region from them.
@@ -330,6 +331,7 @@ If data is being replicated from S3 to S3 then Circus Train will use the AWS S3 
 |`copier-options.s3s3-multipart-copy-part-size-in-bytes`|No|Default value should be OK for most replications. See [TransferManagerConfiguration](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.html)|
 |`copier-options.s3-endpoint-uri`|No|URI of the S3 end-point used by the S3 client. Defaults to `null` which means the client will select the end-point.|
 |`copier-options.s3-server-side-encryption`|No|Whether to enable server side encryption. Defaults to `false`.|
+|`copier-options.canned-acl`|No|AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL.|
 |`copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
 
 ### S3 Secret Configuration

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ If data is being replicated from HDFS to S3 then Circus Train will use a customi
 | `copier-options.upload-retry-count`|No|Maximum number of upload retries. Defaults to `3`|
 | `copier-options.upload-retry-delay-ms`|No|Milliseconds between upload retries. The actual delay will be computed as `delay = attempt * copier-options.upload-retry-delay-ms` where `attempt` is the current retry number. Defaults to `300` ms.|
 | `copier-options.upload-buffer-size`|No|Size of the buffer used to upload the stream of data. If the value is `0` the upload will use the value of the HDFS property `io.file.buffer.size` to configure the buffer. Defaults to `0`|
-| `copier-options.canned-acl`|No|AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL.|
+| `copier-options.canned-acl`|No|AWS Canned ACL name. See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL.|
 | `copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
 
 ##### S3 to S3 copier options
@@ -331,7 +331,7 @@ If data is being replicated from S3 to S3 then Circus Train will use the AWS S3 
 |`copier-options.s3s3-multipart-copy-part-size-in-bytes`|No|Default value should be OK for most replications. See [TransferManagerConfiguration](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.html)|
 |`copier-options.s3-endpoint-uri`|No|URI of the S3 end-point used by the S3 client. Defaults to `null` which means the client will select the end-point.|
 |`copier-options.s3-server-side-encryption`|No|Whether to enable server side encryption. Defaults to `false`.|
-|`copier-options.canned-acl`|No|AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL.|
+|`copier-options.canned-acl`|No|AWS Canned ACL name. See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3S3Copier` will not specify any canned ACL.|
 |`copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
 
 ### S3 Secret Configuration

--- a/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/CannedAclUtils.java
+++ b/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/CannedAclUtils.java
@@ -15,6 +15,8 @@
  */
 package com.hotels.bdp.circustrain.aws;
 
+import java.util.Locale;
+
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 
 public final class CannedAclUtils {
@@ -32,7 +34,7 @@ public final class CannedAclUtils {
       return null;
     }
 
-    cannedAcl = cannedAcl.toLowerCase();
+    cannedAcl = cannedAcl.toLowerCase(Locale.ROOT);
 
     for (CannedAccessControlList acl : CannedAccessControlList.values()) {
       if (acl.toString().equals(cannedAcl)) {

--- a/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/CannedAclUtils.java
+++ b/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/CannedAclUtils.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016-2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.aws;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+public final class CannedAclUtils {
+
+  private CannedAclUtils() {}
+
+  /**
+   * Returns a {@link CannedAccessControlList} from its {@code x-amz-acl} value.
+   *
+   * @param cannedAcl S3 x-amz-acl value
+   * @return The corresponding CannedAccessControlList value
+   */
+  public static CannedAccessControlList toCannedAccessControlList(String cannedAcl) {
+    if (cannedAcl == null) {
+      return null;
+    }
+
+    cannedAcl = cannedAcl.toLowerCase();
+
+    for (CannedAccessControlList acl : CannedAccessControlList.values()) {
+      if (acl.toString().equals(cannedAcl)) {
+        return acl;
+      }
+    }
+
+    throw new IllegalArgumentException("CannedAccessControlList does not contain " + cannedAcl);
+  }
+
+}

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2016-2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.aws;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+public class CannedAclUtilTest {
+
+  @Test
+  public void toCannedAccessControlList() {
+    assertThat(CannedAclUtils.toCannedAccessControlList("bucket-owner-full-control"), is(CannedAccessControlList.BucketOwnerFullControl));
+  }
+
+  @Test
+  public void toNullCannedAccessControlList() {
+    assertThat(CannedAclUtils.toCannedAccessControlList(null), is(nullValue()));
+  }
+
+  @Test
+  public void toCannedAccessControlListCaseSensitiveness() {
+    assertThat(CannedAclUtils.toCannedAccessControlList("bucket-owner-read"), is(CannedAccessControlList.BucketOwnerRead));
+    assertThat(CannedAclUtils.toCannedAccessControlList("BUCKET-OWNER-READ"), is(CannedAccessControlList.BucketOwnerRead));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void toInvalidCannedAccessControlList() {
+    CannedAclUtils.toCannedAccessControlList("all-read-write");
+  }
+
+}

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
@@ -36,7 +36,7 @@ public class CannedAclUtilTest {
   }
 
   @Test
-  public void toCannedAccessControlListCaseSensitiveness() {
+  public void toCannedAccessControlListCaseInsensitiveness() {
     assertThat(CannedAclUtils.toCannedAccessControlList("bucket-owner-read"), is(CannedAccessControlList.BucketOwnerRead));
     assertThat(CannedAclUtils.toCannedAccessControlList("BUCKET-OWNER-READ"), is(CannedAccessControlList.BucketOwnerRead));
   }

--- a/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParser.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class S3MapReduceCpOptionsParser {
   public static final String UPLOAD_RETRY_COUNT = "upload-retry-count";
   public static final String UPLOAD_RETRY_DELAY_MS = "upload-retry-delay-ms";
   public static final String UPLOAD_BUFFER_SIZE = "upload-buffer-size";
+  public static final String CANNED_ACL = "canned-acl";
 
   private final S3MapReduceCpOptions.Builder optionsBuilder;
   private final URI defaultCredentialsProvider;
@@ -143,6 +144,8 @@ public class S3MapReduceCpOptionsParser {
       throw new IllegalArgumentException("Parameter " + UPLOAD_BUFFER_SIZE + " must be a positive number");
     }
     optionsBuilder.uploadBufferSize(uploadBufferSize);
+
+    optionsBuilder.cannedAcl(MapUtils.getString(copierOptions, CANNED_ACL, ConfigurationVariable.CANNED_ACL.defaultValue()));
 
     return optionsBuilder.build();
   }

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.CANNED_ACL;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.COPY_STRATEGY;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.CREDENTIAL_PROVIDER;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.IGNORE_FAILURES;
@@ -56,6 +57,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.codahale.metrics.MetricRegistry;
 
@@ -116,6 +118,7 @@ public class S3MapReduceCpCopierTest {
     when(copierOptions.get(LOG_PATH)).thenReturn("hdfs://path/to/logs/");
     when(copierOptions.get(REGION)).thenReturn("us-east-1");
     when(copierOptions.get(IGNORE_FAILURES)).thenReturn("true");
+    when(copierOptions.get(CANNED_ACL)).thenReturn(CannedAccessControlList.BucketOwnerFullControl.toString());
 
     S3MapReduceCpCopier copier = new S3MapReduceCpCopier(conf, sourceDataBaseLocation, Collections.<Path> emptyList(),
         replicaDataLocation, copierOptions, executor, metricRegistry);
@@ -139,6 +142,7 @@ public class S3MapReduceCpCopierTest {
     assertThat(options.getLogPath(), is(new Path("hdfs://path/to/logs/")));
     assertThat(options.getRegion(), is(Regions.US_EAST_1.getName()));
     assertThat(options.isIgnoreFailures(), is(true));
+    assertThat(options.getCannedAcl(), is(CannedAccessControlList.BucketOwnerFullControl.toString()));
   }
 
   @Test

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.CANNED_ACL;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.COPY_STRATEGY;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.CREDENTIAL_PROVIDER;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.IGNORE_FAILURES;
@@ -80,6 +81,7 @@ public class S3MapReduceCpOptionsParserTest {
     copierOptions.put(UPLOAD_RETRY_COUNT, 5);
     copierOptions.put(UPLOAD_RETRY_DELAY_MS, 520);
     copierOptions.put(UPLOAD_BUFFER_SIZE, 1024);
+    copierOptions.put(CANNED_ACL, "bucket-owner-full-control");
     parser = new S3MapReduceCpOptionsParser(SOURCES, TARGET, DEFAULT_CREDS_PROVIDER);
   }
 
@@ -100,6 +102,7 @@ public class S3MapReduceCpOptionsParserTest {
     assertThat(options.getUploadRetryCount(), is(5));
     assertThat(options.getUploadRetryDelayMs(), is(520L));
     assertThat(options.getUploadBufferSize(), is(1024));
+    assertThat(options.getCannedAcl(), is("bucket-owner-full-control"));
   }
 
   @Test
@@ -419,4 +422,16 @@ public class S3MapReduceCpOptionsParserTest {
     parser.parse(copierOptions);
   }
 
+  @Test
+  public void missingCannedAcl() {
+    copierOptions.remove(CANNED_ACL);
+    S3MapReduceCpOptions options = parser.parse(copierOptions);
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidCannedAcl() {
+    copierOptions.put(CANNED_ACL, "my-canned-acl");
+    parser.parse(copierOptions);
+  }
 }

--- a/circus-train-s3-mapreduce-cp/README.md
+++ b/circus-train-s3-mapreduce-cp/README.md
@@ -30,6 +30,7 @@ The copy is done in map-only job using multipart uploads to improve the throughp
 | `--uploadRetryCount`                    | No       | Maximum number of upload retries. Defaults to `3` |
 | `--uploadRetryDelayMs`                  | No       | Milliseconds between upload retries. The actual delay will be computed as `delay = attempt * uploadRetryDelayMs` where `attempt` is the current retry number. Defaults to `300` ms. |
 | `--uploadBufferSize`                    | No       | Size of the buffer used to upload the stream of data. If the value is `0` the upload will use the value of the HDFS property `io.file.buffer.size` to configure the buffer. Defaults to `0` |
+| `--cannedAcl`                           | No       | AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL. |
 
 ## Architecture
 

--- a/circus-train-s3-mapreduce-cp/README.md
+++ b/circus-train-s3-mapreduce-cp/README.md
@@ -30,7 +30,7 @@ The copy is done in map-only job using multipart uploads to improve the throughp
 | `--uploadRetryCount`                    | No       | Maximum number of upload retries. Defaults to `3` |
 | `--uploadRetryDelayMs`                  | No       | Milliseconds between upload retries. The actual delay will be computed as `delay = attempt * uploadRetryDelayMs` where `attempt` is the current retry number. Defaults to `300` ms. |
 | `--uploadBufferSize`                    | No       | Size of the buffer used to upload the stream of data. If the value is `0` the upload will use the value of the HDFS property `io.file.buffer.size` to configure the buffer. Defaults to `0` |
-| `--cannedAcl`                           | No       | AWS Canned ACL name.  See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL. |
+| `--cannedAcl`                           | No       | AWS Canned ACL name. See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3MapReduceCp` will not specify any canned ACL. |
 
 ## Architecture
 

--- a/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/ConfigurationVariable.java
+++ b/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/ConfigurationVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ final class Constants {
 
 public enum ConfigurationVariable {
 
+  CANNED_ACL("com.hotels.bdp.circustrain.s3mapreducecp.cannedAcl", null),
   CREDENTIAL_PROVIDER("com.hotels.bdp.circustrain.s3mapreducecp.credentialsProvider", null),
   MINIMUM_UPLOAD_PART_SIZE("com.hotels.bdp.circustrain.s3mapreducecp.minimumUploadPartSize",
       String.valueOf(DEFAULT_TRANSFER_MANAGER_CONFIGURATION.getMinimumUploadPartSize())),

--- a/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptions.java
+++ b/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.beust.jcommander.converters.URIConverter;
 import com.beust.jcommander.validators.PositiveInteger;
 import com.google.common.collect.ImmutableMap;
 
+import com.hotels.bdp.circustrain.aws.CannedAclUtils;
 import com.hotels.bdp.circustrain.s3mapreducecp.aws.AwsUtil;
 import com.hotels.bdp.circustrain.s3mapreducecp.jcommander.PathConverter;
 import com.hotels.bdp.circustrain.s3mapreducecp.jcommander.PositiveLong;
@@ -134,6 +135,11 @@ public class S3MapReduceCpOptions {
       return this;
     }
 
+    public Builder cannedAcl(String cannedAcl) {
+      options.setCannedAcl(cannedAcl);
+      return this;
+    }
+
     public S3MapReduceCpOptions build() {
       return options;
     }
@@ -203,6 +209,9 @@ public class S3MapReduceCpOptions {
   @Parameter(names = "--uploadBufferSize", description = "Size of the buffer used to upload the stream of data", validateWith = PositiveInteger.class)
   private int uploadBufferSize = ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue();
 
+  @Parameter(names = "--cannedAcl", description = "AWS Canned ACL")
+  private String cannedAcl = ConfigurationVariable.CANNED_ACL.defaultValue();
+
   public S3MapReduceCpOptions() {}
 
   public S3MapReduceCpOptions(S3MapReduceCpOptions options) {
@@ -226,6 +235,7 @@ public class S3MapReduceCpOptions {
     uploadRetryCount = options.uploadRetryCount;
     uploadRetryDelayMs = options.uploadRetryDelayMs;
     uploadBufferSize = options.uploadBufferSize;
+    cannedAcl = options.cannedAcl;
   }
 
   public boolean isHelp() {
@@ -391,6 +401,15 @@ public class S3MapReduceCpOptions {
     this.uploadBufferSize = uploadBufferSize;
   }
 
+  public String getCannedAcl() {
+    return cannedAcl;
+  }
+
+  public void setCannedAcl(String cannedAcl) {
+    CannedAclUtils.toCannedAccessControlList(cannedAcl);
+    this.cannedAcl = cannedAcl;
+  }
+
   public Map<String, String> toMap() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap
         .<String, String> builder()
@@ -415,7 +434,36 @@ public class S3MapReduceCpOptions {
     if (s3EndpointUri != null) {
       builder.put(ConfigurationVariable.S3_ENDPOINT_URI.getName(), s3EndpointUri.toString());
     }
+    if (cannedAcl != null) {
+      builder.put(ConfigurationVariable.CANNED_ACL.getName(), cannedAcl);
+    }
     return builder.build();
   }
 
+  @Override
+  public String toString() {
+    return "S3MapReduceCpOptions{" +
+            "help=" + help +
+            ", async=" + async +
+            ", sources=" + sources +
+            ", target=" + target +
+            ", credentialsProvider=" + credentialsProvider +
+            ", multipartUploadPartSize=" + multipartUploadPartSize +
+            ", s3ServerSideEncryption=" + s3ServerSideEncryption +
+            ", storageClass='" + storageClass + '\'' +
+            ", maxBandwidth=" + maxBandwidth +
+            ", numberOfUploadWorkers=" + numberOfUploadWorkers +
+            ", multipartUploadThreshold=" + multipartUploadThreshold +
+            ", maxMaps=" + maxMaps +
+            ", copyStrategy='" + copyStrategy + '\'' +
+            ", logPath=" + logPath +
+            ", region='" + region + '\'' +
+            ", ignoreFailures=" + ignoreFailures +
+            ", s3EndpointUri=" + s3EndpointUri +
+            ", uploadRetryCount=" + uploadRetryCount +
+            ", uploadRetryDelayMs=" + uploadRetryDelayMs +
+            ", uploadBufferSize=" + uploadBufferSize +
+            ", cannedAcl='" + cannedAcl + '\'' +
+            '}';
+  }
 }

--- a/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/RetriableFileCopyCommand.java
+++ b/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/mapreduce/RetriableFileCopyCommand.java
@@ -38,10 +38,12 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.Transfer;
 import com.amazonaws.services.s3.transfer.TransferManager;
 
+import com.hotels.bdp.circustrain.aws.CannedAclUtils;
 import com.hotels.bdp.circustrain.s3mapreducecp.ConfigurationVariable;
 import com.hotels.bdp.circustrain.s3mapreducecp.command.RetriableCommand;
 import com.hotels.bdp.circustrain.s3mapreducecp.io.ThrottledInputStream;
@@ -157,6 +159,14 @@ public class RetriableFileCopyCommand extends RetriableCommand<Long> {
     try {
       PutObjectRequest request = new PutObjectRequest(uploadDescriptor.getBucketName(), uploadDescriptor.getKey(),
           input, uploadDescriptor.getMetadata());
+
+      String cannedAcl = context.getConfiguration().get(ConfigurationVariable.CANNED_ACL.getName());
+      if (cannedAcl != null) {
+        CannedAccessControlList acl = CannedAclUtils.toCannedAccessControlList(cannedAcl);
+        LOG.debug("Using CannedACL {}", acl.name());
+        request.withCannedAcl(acl);
+      }
+
       // We add 1 to the buffer size as per the com.amazonaws.RequestClientOptions doc
       request.getRequestClientOptions().setReadLimit(bufferSize + 1);
       return transferManager.upload(request);

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.StorageClass;
 
 public class S3MapReduceCpOptionsTest {
@@ -57,6 +58,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(3));
     assertThat(options.getUploadRetryDelayMs(), is(300L));
     assertThat(options.getUploadBufferSize(), is(0));
+    assertThat(options.getCannedAcl(), is(nullValue()));
   }
 
   @Test
@@ -86,6 +88,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -118,6 +121,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -146,6 +150,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -174,6 +179,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -206,6 +212,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -235,6 +242,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -263,6 +271,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -291,6 +300,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -320,6 +330,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -349,6 +360,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -378,6 +390,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -410,6 +423,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -439,6 +453,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -471,6 +486,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -500,6 +516,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(10));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -529,6 +546,7 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(666L));
     assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
   @Test
@@ -558,6 +576,39 @@ public class S3MapReduceCpOptionsTest {
     assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
     assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
     assertThat(options.getUploadBufferSize(), is(512));
+    assertThat(options.getCannedAcl(), is(ConfigurationVariable.CANNED_ACL.defaultValue()));
   }
 
+  @Test
+  public void builderWithCannedAcl() {
+    S3MapReduceCpOptions options = S3MapReduceCpOptions
+            .builder(SOURCES, TARGET)
+            .cannedAcl(CannedAccessControlList.BucketOwnerFullControl.toString())
+            .build();
+    assertThat(options.isHelp(), is(false));
+    assertThat(options.isBlocking(), is(true));
+    assertThat(options.getSources(), is(SOURCES));
+    assertThat(options.getTarget(), is(TARGET));
+    assertThat(options.getCredentialsProvider(), is(ConfigurationVariable.CREDENTIAL_PROVIDER.defaultURIValue()));
+    assertThat(options.getMultipartUploadPartSize(),
+            is(ConfigurationVariable.MINIMUM_UPLOAD_PART_SIZE.defaultLongValue()));
+    assertThat(options.isS3ServerSideEncryption(),
+            is(ConfigurationVariable.S3_SERVER_SIDE_ENCRYPTION.defaultBooleanValue()));
+    assertThat(options.getStorageClass(), is(ConfigurationVariable.STORAGE_CLASS.defaultValue()));
+    assertThat(options.getMaxBandwidth(), is(ConfigurationVariable.MAX_BANDWIDTH.defaultLongValue()));
+    assertThat(options.getNumberOfUploadWorkers(),
+            is(ConfigurationVariable.NUMBER_OF_UPLOAD_WORKERS.defaultIntValue()));
+    assertThat(options.getMultipartUploadThreshold(),
+            is(ConfigurationVariable.MULTIPART_UPLOAD_THRESHOLD.defaultLongValue()));
+    assertThat(options.getMaxMaps(), is(ConfigurationVariable.MAX_MAPS.defaultIntValue()));
+    assertThat(options.getCopyStrategy(), is(ConfigurationVariable.COPY_STRATEGY.defaultValue()));
+    assertThat(options.getLogPath(), is(nullValue()));
+    assertThat(options.getRegion(), is(ConfigurationVariable.REGION.defaultValue()));
+    assertThat(options.isIgnoreFailures(), is(ConfigurationVariable.IGNORE_FAILURES.defaultBooleanValue()));
+    assertThat(options.getS3EndpointUri(), is(ConfigurationVariable.S3_ENDPOINT_URI.defaultURIValue()));
+    assertThat(options.getUploadRetryCount(), is(ConfigurationVariable.UPLOAD_RETRY_COUNT.defaultIntValue()));
+    assertThat(options.getUploadRetryDelayMs(), is(ConfigurationVariable.UPLOAD_RETRY_DELAY_MS.defaultLongValue()));
+    assertThat(options.getUploadBufferSize(), is(ConfigurationVariable.UPLOAD_BUFFER_SIZE.defaultIntValue()));
+    assertThat(options.getCannedAcl(), is(CannedAccessControlList.BucketOwnerFullControl.toString()));
+  }
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3Copier.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3Copier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,6 +155,11 @@ public class S3S3Copier implements Copier {
 
       CopyObjectRequest copyObjectRequest = new CopyObjectRequest(s3ObjectSummary.getBucketName(),
           s3ObjectSummary.getKey(), targetS3Uri.getBucket(), targetKey);
+
+      if (s3s3CopierOptions.getCannedAcl() != null) {
+        copyObjectRequest.withCannedAccessControlList(s3s3CopierOptions.getCannedAcl());
+      }
+
       applyObjectMetadata(copyObjectRequest);
 
       TransferStateChangeListener stateChangeListener = new TransferStateChangeListener() {

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,11 @@ import java.util.Map;
 
 import org.apache.commons.collections.MapUtils;
 
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
+
+import com.hotels.bdp.circustrain.aws.CannedAclUtils;
 
 public class S3S3CopierOptions {
 
@@ -46,7 +49,12 @@ public class S3S3CopierOptions {
      * {@link ObjectMetadata#setSSEAlgorithm(String)}
      * Whether to enable server side encryption.
      */
-    S3_SERVER_SIDE_ENCRYPTION("s3-server-side-encryption");
+    S3_SERVER_SIDE_ENCRYPTION("s3-server-side-encryption"),
+    /**
+     * {@link com.amazonaws.services.s3.model.CannedAccessControlList}
+     * Optional AWS Canned ACL
+     */
+    CANNED_ACL("canned-acl");
 
     private final String keyName;
 
@@ -99,6 +107,15 @@ public class S3S3CopierOptions {
 
   public Boolean isS3ServerSideEncryption() {
     return MapUtils.getBoolean(copierOptions, Keys.S3_SERVER_SIDE_ENCRYPTION.keyName(), false);
+  }
+
+  public CannedAccessControlList getCannedAcl() {
+     String cannedAcl = MapUtils.getString(copierOptions, Keys.CANNED_ACL.keyName(), null);
+     if (cannedAcl != null) {
+       return CannedAclUtils.toCannedAccessControlList(cannedAcl);
+     }
+
+     return null;
   }
 
 }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 
 public class S3S3CopierOptionsTest {
 
@@ -79,6 +81,19 @@ public class S3S3CopierOptionsTest {
   public void defaultS3ServerSideEncryption() throws Exception {
     S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
     assertThat(options.isS3ServerSideEncryption(), is(false));
+  }
+
+  @Test
+  public void getCannedAcl() throws Exception {
+    copierOptions.put(S3S3CopierOptions.Keys.CANNED_ACL.keyName(), CannedAccessControlList.BucketOwnerFullControl.toString());
+    S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
+    assertThat(options.getCannedAcl(), is(CannedAccessControlList.BucketOwnerFullControl));
+  }
+
+  @Test
+  public void getCannedAclDefaultIsNull() throws Exception {
+    S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
+    assertNull(options.getCannedAcl());
   }
 
 }


### PR DESCRIPTION
Fixes #99.  Adds an optional `copier-options.canned-acl` which, if set, configures the `x-amz-acl` header on the S3 requests in both the `S3MapReduceCpCopier` and `S3S3Copier`.  The default remains `null`, which avoids setting any canned ACL at all.