### PR TITLE
Add Spring retry to S3S3copier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 13.2.2 - 2019-02-20
-### Changed
-* Added a retry mechanism to handle AWS S3 copying bug
-* Added a configuration parameter to support a configurable number of maximum attempts at copying
+### Added
+* Configurable retry mechanism to handle flaky AWS S3 to S3 copying. See [#56](https://github.com/HotelsDotCom/circus-train/issues/56).
 
 ## TBD
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 13.2.2 - 2019-02-20
+### Changed
+* Added a retry mechanism to handle AWS S3 copying bug
+* Added a configuration parameter to support a configurable number of maximum attempts at copying
+
 ## TBD
 ### Fixed
 * Clear partitioned state correctly for `SnsListener`. See [#104](https://github.com/HotelsDotCom/circus-train/issues/104).

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ If data is being replicated from S3 to S3 then Circus Train will use the AWS S3 
 |`copier-options.s3-server-side-encryption`|No|Whether to enable server side encryption. Defaults to `false`.|
 |`copier-options.canned-acl`|No|AWS Canned ACL name. See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3S3Copier` will not specify any canned ACL.|
 |`copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
+|`copier-options.s3s3copier-retry-maxattempts`|No|Controls the maximum number of attempts if AWS throws an error during copy. Default value is 3.|
 
 ### S3 Secret Configuration
 When configuring a job for replication to or from S3, the AWS access key and secret key with read/write access to the configured S3 buckets must be supplied. To protect these from being exposed in the job's Hadoop configuration, Circus Train expects them to be stored using the Hadoop Credential Provider and the JCEKS URL provided in the Circus Train configuration `security.credential-provider` property. This property is only required if a specific set of credentials is needed or if Circus Train runs on a non-AWS environment. If it is not set then the credentials of the instance where Circus Train runs will be used - note this scenario is only valid when Circus Train is executed on an AWS environment, i.e. EC2/EMR instance.

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -51,6 +51,10 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
 
     <!-- Java EL: needed for compatibility with new Spring and hibernate-validator -->
     <dependency>

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrain.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrain.java
@@ -32,6 +32,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Profile;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
 
@@ -77,6 +78,7 @@ import com.hotels.bdp.circustrain.manifest.ManifestAttributes;
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 
 @SpringBootApplication
+@EnableRetry
 @EnableConfigurationProperties
 @ComponentScan(basePackages = {
     "com.hotels.bdp.circustrain.avro",

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-with-no-partitions-mirror.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-with-no-partitions-mirror.yml
@@ -8,3 +8,5 @@ table-replications:
       table-name: ct_table_p_copy
 security:
   credential-provider: jceks://file/${config-location}/aws.jceks
+copier-options:
+  s3s3copier-retry-maxattempts: 3

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-s3-s3-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-s3-s3-replication.yml
@@ -7,3 +7,5 @@ table-replications:
       table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
 security:
   credential-provider: jceks://file/${config-location}/aws.jceks
+copier-options:
+  s3s3copier-retry-maxattempts: 3

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
@@ -34,7 +34,7 @@ import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.aws.S3Schemes;
 import com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3ClientFactory;
 import com.hotels.bdp.circustrain.s3s3copier.aws.ListObjectsRequestFactory;
-import com.hotels.bdp.circustrain.s3s3copier.aws.TransferManagerFactory;
+import com.hotels.bdp.circustrain.s3s3copier.aws.RetryableTransferManagerFactory;
 
 @Profile({ Modules.REPLICATION })
 @Component
@@ -43,18 +43,18 @@ public class S3S3CopierFactory implements CopierFactory {
 
   private final AmazonS3ClientFactory clientFactory;
   private final ListObjectsRequestFactory listObjectsRequestFactory;
-  private final TransferManagerFactory transferManagerFactory;
+  private final RetryableTransferManagerFactory retryableTransferManagerFactory;
   private final MetricRegistry runningMetricsRegistry;
 
   @Autowired
   public S3S3CopierFactory(
       AmazonS3ClientFactory clientFactory,
       ListObjectsRequestFactory listObjectsRequestFactory,
-      TransferManagerFactory transferManagerFactory,
+      RetryableTransferManagerFactory retryableTransferManagerFactory,
       MetricRegistry runningMetricsRegistry) {
     this.clientFactory = clientFactory;
     this.listObjectsRequestFactory = listObjectsRequestFactory;
-    this.transferManagerFactory = transferManagerFactory;
+    this.retryableTransferManagerFactory = retryableTransferManagerFactory;
     this.runningMetricsRegistry = runningMetricsRegistry;
   }
 
@@ -71,7 +71,7 @@ public class S3S3CopierFactory implements CopierFactory {
       Path replicaLocation,
       Map<String, Object> copierOptions) {
     return new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, clientFactory,
-        transferManagerFactory, listObjectsRequestFactory, runningMetricsRegistry,
+        retryableTransferManagerFactory, listObjectsRequestFactory, runningMetricsRegistry,
         new S3S3CopierOptions(copierOptions));
   }
 

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -123,7 +123,7 @@ public class S3S3CopierOptions {
   }
 
   public int getMaxCopyAttempts() {
-    Integer maxCopyAttempts = MapUtils.getInteger(copierOptions, Keys.MAX_COPY_ATTEMPTS.keyName(), 1);
+    Integer maxCopyAttempts = MapUtils.getInteger(copierOptions, Keys.MAX_COPY_ATTEMPTS.keyName(), 3);
     return maxCopyAttempts < 1 ? 1 : maxCopyAttempts;
   }
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -124,6 +124,6 @@ public class S3S3CopierOptions {
 
   public int getMaxCopyAttempts() {
     Integer maxCopyAttempts = MapUtils.getInteger(copierOptions, Keys.MAX_COPY_ATTEMPTS.keyName(), 3);
-    return maxCopyAttempts < 1 ? 1 : maxCopyAttempts;
+    return maxCopyAttempts < 1 ? 3 : maxCopyAttempts;
   }
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -56,7 +56,7 @@ public class S3S3CopierOptions {
      */
     CANNED_ACL("canned-acl"),
     /**
-     * Number of copy attempts to allow when copying from S3 to S3. Default value is 1.
+     * Number of copy attempts to allow when copying from S3 to S3. Default value is 3.
      */
     MAX_COPY_ATTEMPTS("s3s3copier-retry-maxattempts");
 

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -54,7 +54,11 @@ public class S3S3CopierOptions {
      * {@link com.amazonaws.services.s3.model.CannedAccessControlList}
      * Optional AWS Canned ACL
      */
-    CANNED_ACL("canned-acl");
+    CANNED_ACL("canned-acl"),
+    /**
+     * Number of copy attempts to allow when copying from S3 to S3. Default value is 1.
+     */
+    MAX_COPY_ATTEMPTS("s3s3copier-retry-maxattempts");
 
     private final String keyName;
 
@@ -118,4 +122,8 @@ public class S3S3CopierOptions {
      return null;
   }
 
+  public int getMaxCopyAttempts() {
+    Integer maxCopyAttempts = MapUtils.getInteger(copierOptions, Keys.MAX_COPY_ATTEMPTS.keyName(), 1);
+    return maxCopyAttempts < 1 ? 1 : maxCopyAttempts;
+  }
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -31,6 +31,7 @@ public class RetryableTransferManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(RetryableTransferManager.class);
   private static final int BACKOFF_DELAY_MS = 500;
+  private static final int MAX_RETRY_ATTEMPTS = 3;
   private TransferManager transferManager;
   private AmazonS3 srcClient;
   private int retryAttempt = 0;
@@ -41,11 +42,14 @@ public class RetryableTransferManager {
   }
 
   @Retryable(value = { AmazonS3Exception.class },
+      maxAttempts = MAX_RETRY_ATTEMPTS,
       backoff = @Backoff(delay = BACKOFF_DELAY_MS, multiplier = 2))
   public Copy copy(CopyObjectRequest copyObjectRequest, TransferStateChangeListener stateChangeListener) {
     retryAttempt++;
     LOG.info("copying attempt {}/3", retryAttempt);
-    return transferManager.copy(copyObjectRequest, srcClient, stateChangeListener);
+    Copy copy = transferManager.copy(copyObjectRequest, srcClient, stateChangeListener);
+    retryAttempt = 0;
+    return copy;
   }
 
   public void shutdownNow() {

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2016-2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.s3s3copier.aws;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
+
+public class RetryableTransferManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RetryableTransferManager.class);
+  private static final int BACKOFF_DELAY_MS = 500;
+  private TransferManager transferManager;
+  private AmazonS3 srcClient;
+  private int retryAttempt = 0;
+
+  public RetryableTransferManager(TransferManager transferManager, AmazonS3 srcClient) {
+    this.transferManager = transferManager;
+    this.srcClient = srcClient;
+  }
+
+  @Retryable(value = { AmazonS3Exception.class },
+      backoff = @Backoff(delay = BACKOFF_DELAY_MS, multiplier = 2))
+  public Copy copy(CopyObjectRequest copyObjectRequest, TransferStateChangeListener stateChangeListener) {
+    retryAttempt++;
+    LOG.info("copying attempt {}/3", retryAttempt);
+    return transferManager.copy(copyObjectRequest, srcClient, stateChangeListener);
+  }
+
+  public void shutdownNow() {
+    transferManager.shutdownNow();
+  }
+}

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -46,7 +46,7 @@ public class RetryableTransferManager {
       backoff = @Backoff(delay = BACKOFF_DELAY_MS, multiplier = 2))
   public Copy copy(CopyObjectRequest copyObjectRequest, TransferStateChangeListener stateChangeListener) {
     retryAttempt++;
-    LOG.info("copying attempt {}/3", retryAttempt);
+    LOG.info("copying attempt {}/{}", retryAttempt, MAX_ATTEMPTS);
     Copy copy = transferManager.copy(copyObjectRequest, srcClient, stateChangeListener);
     retryAttempt = 0;
     return copy;

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -31,7 +31,7 @@ public class RetryableTransferManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(RetryableTransferManager.class);
   private static final int BACKOFF_DELAY_MS = 500;
-  private static final int MAX_RETRY_ATTEMPTS = 3;
+  private static final int MAX_ATTEMPTS = 3;
   private TransferManager transferManager;
   private AmazonS3 srcClient;
   private int retryAttempt = 0;
@@ -42,7 +42,7 @@ public class RetryableTransferManager {
   }
 
   @Retryable(value = { AmazonS3Exception.class },
-      maxAttempts = MAX_RETRY_ATTEMPTS,
+      maxAttempts = MAX_ATTEMPTS,
       backoff = @Backoff(delay = BACKOFF_DELAY_MS, multiplier = 2))
   public Copy copy(CopyObjectRequest copyObjectRequest, TransferStateChangeListener stateChangeListener) {
     retryAttempt++;

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -26,6 +26,7 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -60,7 +61,7 @@ public class RetryableTransferManager {
         }
       });
     } catch (Throwable throwable) {
-      throw new AmazonS3Exception(throwable.getMessage());
+      throw new AmazonClientException(throwable);
     }
   }
 

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerFactory.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerFactory.java
@@ -33,7 +33,7 @@ public class RetryableTransferManagerFactory {
         .withMultipartCopyPartSize(s3s3CopierOptions.getMultipartCopyPartSize())
         .withS3Client(targetS3Client)
         .build();
-    return new RetryableTransferManager(transferManager, srcClient);
+    return new RetryableTransferManager(transferManager, srcClient, s3s3CopierOptions.getMaxCopyAttempts());
   }
 
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerFactory.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,16 @@ import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.hotels.bdp.circustrain.s3s3copier.S3S3CopierOptions;
 
 @Component
-public class TransferManagerFactory {
+public class RetryableTransferManagerFactory {
 
-  public TransferManager newInstance(AmazonS3 targetS3Client, S3S3CopierOptions s3s3CopierOptions) {
-    return TransferManagerBuilder
+  public RetryableTransferManager newInstance(AmazonS3 targetS3Client, S3S3CopierOptions s3s3CopierOptions, AmazonS3 srcClient) {
+    TransferManager transferManager = TransferManagerBuilder
         .standard()
         .withMultipartCopyThreshold(s3s3CopierOptions.getMultipartCopyThreshold())
         .withMultipartCopyPartSize(s3s3CopierOptions.getMultipartCopyPartSize())
         .withS3Client(targetS3Client)
         .build();
+    return new RetryableTransferManager(transferManager, srcClient);
   }
 
 }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,21 +36,21 @@ import com.google.common.collect.Lists;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3ClientFactory;
 import com.hotels.bdp.circustrain.s3s3copier.aws.ListObjectsRequestFactory;
-import com.hotels.bdp.circustrain.s3s3copier.aws.TransferManagerFactory;
+import com.hotels.bdp.circustrain.s3s3copier.aws.RetryableTransferManagerFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public class S3S3CopierFactoryTest {
 
   private @Mock AmazonS3ClientFactory clientFactory;
   private @Mock ListObjectsRequestFactory listObjectsRequestFactory;
-  private @Mock TransferManagerFactory transferManagerFactory;
+  private @Mock RetryableTransferManagerFactory retryableTransferManagerFactory;
   private @Mock MetricRegistry metricsRegistry;
 
   private S3S3CopierFactory factory;
 
   @Before
   public void setUp() {
-    factory = new S3S3CopierFactory(clientFactory, listObjectsRequestFactory, transferManagerFactory, metricsRegistry);
+    factory = new S3S3CopierFactory(clientFactory, listObjectsRequestFactory, retryableTransferManagerFactory, metricsRegistry);
   }
 
   @Test

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -104,16 +104,16 @@ public class S3S3CopierOptionsTest {
   }
 
   @Test
-  public void getMaxCopyAttemptsDefaultIsOne() throws Exception {
+  public void getMaxCopyAttemptsDefaultIsThree() throws Exception {
     S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
     assertThat(options.getMaxCopyAttempts(), is(3));
   }
 
   @Test
-  public void getMaxCopyAttemptsDefaultIsOneIfLessThanOne() throws Exception {
+  public void getMaxCopyAttemptsDefaultIfLessThanOne() throws Exception {
     copierOptions.put(S3S3CopierOptions.Keys.MAX_COPY_ATTEMPTS.keyName(), -1);
     S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
-    assertThat(options.getMaxCopyAttempts(), is(1));
+    assertThat(options.getMaxCopyAttempts(), is(3));
   }
 
 }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -106,7 +106,7 @@ public class S3S3CopierOptionsTest {
   @Test
   public void getMaxCopyAttemptsDefaultIsOne() throws Exception {
     S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
-    assertThat(options.getMaxCopyAttempts(), is(1));
+    assertThat(options.getMaxCopyAttempts(), is(3));
   }
 
   @Test

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -96,4 +96,24 @@ public class S3S3CopierOptionsTest {
     assertNull(options.getCannedAcl());
   }
 
+  @Test
+  public void getMaxCopyAttempts() throws Exception {
+    copierOptions.put(S3S3CopierOptions.Keys.MAX_COPY_ATTEMPTS.keyName(), 3);
+    S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
+    assertThat(options.getMaxCopyAttempts(), is(3));
+  }
+
+  @Test
+  public void getMaxCopyAttemptsDefaultIsOne() throws Exception {
+    S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
+    assertThat(options.getMaxCopyAttempts(), is(1));
+  }
+
+  @Test
+  public void getMaxCopyAttemptsDefaultIsOneIfLessThanOne() throws Exception {
+    copierOptions.put(S3S3CopierOptions.Keys.MAX_COPY_ATTEMPTS.keyName(), -1);
+    S3S3CopierOptions options = new S3S3CopierOptions(copierOptions);
+    assertThat(options.getMaxCopyAttempts(), is(1));
+  }
+
 }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
@@ -409,7 +409,7 @@ public class S3S3CopierTest {
         .thenReturn(mockedRetryableTransferManager);
     Copy copy = Mockito.mock(Copy.class);
     when(mockedRetryableTransferManager.copy(any(CopyObjectRequest.class),
-        any(TransferStateChangeListener.class))).thenThrow(new AmazonS3Exception("S3 error"));
+        any(TransferStateChangeListener.class))).thenThrow(new AmazonClientException("S3 error"));
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
@@ -44,8 +44,10 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@ContextConfiguration(classes = RetryableTransferManagerTest.ContextConfiguration.class)
 public class RetryableTransferManagerTest {
+
+  private static int MAX_COPY_ATTEMPTS = 3;
 
   @Autowired
   private TransferManager mockedTransferManager;
@@ -107,7 +109,7 @@ public class RetryableTransferManagerTest {
     @Bean
     public RetryableTransferManager retriableTransferManager(TransferManager transferManager) {
       AmazonS3 srcClient = Mockito.mock(AmazonS3.class);
-      return new RetryableTransferManager(transferManager, srcClient);
+      return new RetryableTransferManager(transferManager, srcClient, MAX_COPY_ATTEMPTS);
     }
   }
 }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
@@ -48,14 +48,14 @@ import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 public class RetryableTransferManagerTest {
 
   @Autowired
-  private TransferManager transferManager;
+  private TransferManager mockedTransferManager;
 
   @Autowired
   private RetryableTransferManager retryableTransferManager;
 
   @Before
   public void setup() {
-    Mockito.reset(transferManager);
+    Mockito.reset(mockedTransferManager);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class RetryableTransferManagerTest {
     CopyObjectRequest copyObjectRequest = Mockito.mock(CopyObjectRequest.class);
     TransferStateChangeListener stateChangeListener = Mockito.mock(TransferStateChangeListener.class);
     Copy copy = Mockito.mock(Copy.class);
-    when(transferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
+    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
         any(TransferStateChangeListener.class))).thenThrow(new AmazonS3Exception("S3 error"))
         .thenThrow(new AmazonS3Exception("S3 error"))
         .thenReturn(copy);
@@ -73,7 +73,7 @@ public class RetryableTransferManagerTest {
     } catch (Exception e) {
       fail("Should not have thrown exception");
     }
-    verify(transferManager, times(3)).copy(any(CopyObjectRequest.class),
+    verify(mockedTransferManager, times(3)).copy(any(CopyObjectRequest.class),
         any(AmazonS3.class), any(TransferStateChangeListener.class));
   }
 
@@ -81,7 +81,7 @@ public class RetryableTransferManagerTest {
   public void copyThrowExceptionWhenS3ThrowsExceptionThreeTimes() throws Exception {
     CopyObjectRequest copyObjectRequest = Mockito.mock(CopyObjectRequest.class);
     TransferStateChangeListener stateChangeListener = Mockito.mock(TransferStateChangeListener.class);
-    when(transferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
+    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
         any(TransferStateChangeListener.class))).thenThrow(new AmazonS3Exception("S3 error"))
         .thenThrow(new AmazonS3Exception("S3 error"))
         .thenThrow(new AmazonS3Exception("S3 error"));
@@ -89,7 +89,7 @@ public class RetryableTransferManagerTest {
       retryableTransferManager.copy(copyObjectRequest, stateChangeListener);
       fail("Exception should have been thrown");
     } catch (Exception e) {
-      verify(transferManager, times(3)).copy(any(CopyObjectRequest.class),
+      verify(mockedTransferManager, times(3)).copy(any(CopyObjectRequest.class),
           any(AmazonS3.class), any(TransferStateChangeListener.class));
       assertThat(e.getMessage(), startsWith("S3 error"));
     }

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManagerTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2016-2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.s3s3copier.aws;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class RetryableTransferManagerTest {
+
+  @Autowired
+  private TransferManager transferManager;
+
+  @Autowired
+  private RetryableTransferManager retryableTransferManager;
+
+  @Before
+  public void setup() {
+    Mockito.reset(transferManager);
+  }
+
+  @Test
+  public void copyRetryWhenS3ThrowsException() throws Exception {
+    CopyObjectRequest copyObjectRequest = Mockito.mock(CopyObjectRequest.class);
+    TransferStateChangeListener stateChangeListener = Mockito.mock(TransferStateChangeListener.class);
+    Copy copy = Mockito.mock(Copy.class);
+    when(transferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
+        any(TransferStateChangeListener.class))).thenThrow(new AmazonS3Exception("S3 error"))
+        .thenThrow(new AmazonS3Exception("S3 error"))
+        .thenReturn(copy);
+    try {
+      Copy copyResult = retryableTransferManager.copy(copyObjectRequest, stateChangeListener);
+      assertThat(copyResult, is(copy));
+    } catch (Exception e) {
+      fail("Should not have thrown exception");
+    }
+    verify(transferManager, times(3)).copy(any(CopyObjectRequest.class),
+        any(AmazonS3.class), any(TransferStateChangeListener.class));
+  }
+
+  @Test
+  public void copyThrowExceptionWhenS3ThrowsExceptionThreeTimes() throws Exception {
+    CopyObjectRequest copyObjectRequest = Mockito.mock(CopyObjectRequest.class);
+    TransferStateChangeListener stateChangeListener = Mockito.mock(TransferStateChangeListener.class);
+    when(transferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
+        any(TransferStateChangeListener.class))).thenThrow(new AmazonS3Exception("S3 error"))
+        .thenThrow(new AmazonS3Exception("S3 error"))
+        .thenThrow(new AmazonS3Exception("S3 error"));
+    try {
+      retryableTransferManager.copy(copyObjectRequest, stateChangeListener);
+      fail("Exception should have been thrown");
+    } catch (Exception e) {
+      verify(transferManager, times(3)).copy(any(CopyObjectRequest.class),
+          any(AmazonS3.class), any(TransferStateChangeListener.class));
+      assertThat(e.getMessage(), startsWith("S3 error"));
+    }
+  }
+
+  @Configuration
+  @EnableRetry
+  @EnableAspectJAutoProxy(proxyTargetClass=true)
+  public static class ContextConfiguration {
+    @Bean
+    public TransferManager transferManager() {
+      return Mockito.mock(TransferManager.class);
+    }
+
+    @Bean
+    public RetryableTransferManager retriableTransferManager(TransferManager transferManager) {
+      AmazonS3 srcClient = Mockito.mock(AmazonS3.class);
+      return new RetryableTransferManager(transferManager, srcClient);
+    }
+  }
+}


### PR DESCRIPTION
Fix for [issue 56](https://github.com/HotelsDotCom/circus-train/issues/56).

`RetrayableTransferManager` wraps `TransferManager.copy()` in order to provide a retry mechanism, implemented using Spring retry.