### PR TITLE
Upgraded aws sdk to remove deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Clear partitioned state correctly for `SnsListener`. See [#104](https://github.com/HotelsDotCom/circus-train/issues/104).
 * Fixed issue where in certain cases the table location of a partitioned table would be scheduled for housekeeping.
 * Removed default script for creating a housekeeping schema to allow the use of schemas that are already created. See [#111](https://github.com/HotelsDotCom/circus-train/issues/111).
-* Upgraded aws sdk to remove deprecation warning. See [#102](https://github.com/HotelsDotCom/circus-train/issues/102).
+* Upgraded AWS SDK to remove deprecation warning. See [#102](https://github.com/HotelsDotCom/circus-train/issues/102).
 
 ### Added
 * Configurable retry mechanism to handle flaky AWS S3 to S3 copying. See [#56](https://github.com/HotelsDotCom/circus-train/issues/56).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 13.2.2 - 2019-02-25
-### Fixed
-* Upgraded aws sdk to remove deprecation warning. See [#102](https://github.com/HotelsDotCom/circus-train/issues/102).
-
-## 13.2.2 - 2019-02-20
-### Added
-* Configurable retry mechanism to handle flaky AWS S3 to S3 copying. See [#56](https://github.com/HotelsDotCom/circus-train/issues/56).
-
 ## TBD
 ### Changed
 * Updated `housekeeping` version to 3.0.6 (was 3.0.5).
@@ -15,6 +7,10 @@
 * Clear partitioned state correctly for `SnsListener`. See [#104](https://github.com/HotelsDotCom/circus-train/issues/104).
 * Fixed issue where in certain cases the table location of a partitioned table would be scheduled for housekeeping.
 * Removed default script for creating a housekeeping schema to allow the use of schemas that are already created. See [#111](https://github.com/HotelsDotCom/circus-train/issues/111).
+* Upgraded aws sdk to remove deprecation warning. See [#102](https://github.com/HotelsDotCom/circus-train/issues/102).
+
+### Added
+* Configurable retry mechanism to handle flaky AWS S3 to S3 copying. See [#56](https://github.com/HotelsDotCom/circus-train/issues/56).
 
 ## 13.2.1 - 2019-01-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.2.2 - 2019-02-25
+### Fixed
+* Upgraded aws sdk to remove deprecation warning. See [#102](https://github.com/HotelsDotCom/circus-train/issues/102).
+
 ## 13.2.2 - 2019-02-20
 ### Added
 * Configurable retry mechanism to handle flaky AWS S3 to S3 copying. See [#56](https://github.com/HotelsDotCom/circus-train/issues/56).

--- a/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfiguration.java
+++ b/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfiguration.java
@@ -20,21 +20,16 @@ import static java.lang.String.format;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.client.builder.ExecutorFactory;
-import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 
@@ -43,19 +38,9 @@ public class SnsConfiguration {
 
   @Bean
   AmazonSNSAsync amazonSNS(ListenerConfig config, AWSCredentialsProvider awsCredentialsProvider) {
-    ClientConfiguration clientConfiguration = new ClientConfiguration().withRetryPolicy(
-        PredefinedRetryPolicies.getDefaultRetryPolicy());
-    ExecutorFactory executorFactory = new ExecutorFactory() {
-      @Override
-      public ExecutorService newExecutor() {
-        return Executors.newSingleThreadScheduledExecutor();
-      }
-    };
     return AmazonSNSAsyncClient.asyncBuilder()
-        .withClientConfiguration(clientConfiguration)
         .withCredentials(awsCredentialsProvider)
         .withRegion(config.getRegion())
-        .withExecutorFactory(executorFactory)
         .build();
   }
 

--- a/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfiguration.java
+++ b/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,21 +33,30 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.client.builder.ExecutorFactory;
 import com.amazonaws.retry.PredefinedRetryPolicies;
+import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 
 @Configuration
 public class SnsConfiguration {
 
   @Bean
-  AmazonSNSAsyncClient amazonSNS(ListenerConfig config, AWSCredentialsProvider awsCredentialsProvider) {
-    AmazonSNSAsyncClient client = new AmazonSNSAsyncClient(awsCredentialsProvider,
-        new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicy()),
-        Executors.newSingleThreadScheduledExecutor());
-    client.setRegion(Region.getRegion(Regions.fromName(config.getRegion())));
-    return client;
+  AmazonSNSAsync amazonSNS(ListenerConfig config, AWSCredentialsProvider awsCredentialsProvider) {
+    ClientConfiguration clientConfiguration = new ClientConfiguration().withRetryPolicy(
+        PredefinedRetryPolicies.getDefaultRetryPolicy());
+    ExecutorFactory executorFactory = new ExecutorFactory() {
+      @Override
+      public ExecutorService newExecutor() {
+        return Executors.newSingleThreadScheduledExecutor();
+      }
+    };
+    return AmazonSNSAsyncClient.asyncBuilder()
+        .withClientConfiguration(clientConfiguration)
+        .withCredentials(awsCredentialsProvider)
+        .withRegion(config.getRegion())
+        .withExecutorFactory(executorFactory)
+        .build();
   }
 
   @Bean

--- a/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListener.java
+++ b/circus-train-aws-sns/src/main/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListener.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PreDestroy;
 
@@ -32,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -64,7 +63,7 @@ public class SnsListener implements LocomotiveListener, SourceCatalogListener, R
   /** http://docs.aws.amazon.com/sns/latest/dg/large-payload-raw-message.html */
   private static final int SNS_MESSAGE_SIZE_LIMIT = 256 * 1024;
 
-  private final AmazonSNSAsyncClient sns;
+  private final AmazonSNSAsync sns;
   private final ListenerConfig config;
   private final ObjectWriter startWriter;
   private final Clock clock;
@@ -78,11 +77,11 @@ public class SnsListener implements LocomotiveListener, SourceCatalogListener, R
   private LinkedHashMap<String, String> partitionKeyTypes;
 
   @Autowired
-  public SnsListener(AmazonSNSAsyncClient sns, ListenerConfig config) {
+  public SnsListener(AmazonSNSAsync sns, ListenerConfig config) {
     this(sns, config, Clock.DEFAULT);
   }
 
-  SnsListener(AmazonSNSAsyncClient sns, ListenerConfig config, Clock clock) {
+  SnsListener(AmazonSNSAsync sns, ListenerConfig config, Clock clock) {
     this.clock = clock;
     LOG
         .info("Starting listener, topics: start={}, success={}, fail={}", config.getStartTopic(),
@@ -233,8 +232,6 @@ public class SnsListener implements LocomotiveListener, SourceCatalogListener, R
   @PreDestroy
   public void flush() throws InterruptedException {
     LOG.debug("Terminating...");
-    sns.getExecutorService().shutdown();
-    sns.getExecutorService().awaitTermination(60, TimeUnit.SECONDS);
     sns.shutdown();
     LOG.debug("Terminated.");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
     <spring-platform.version>2.0.8.RELEASE</spring-platform.version>
     <!-- BEGIN: AWS jdk version + dependencies -->
-    <aws-jdk.version>1.11.431</aws-jdk.version>
+    <aws-jdk.version>1.11.503</aws-jdk.version>
     <httpcomponents.httpclient.version>4.5.5</httpcomponents.httpclient.version>
     <jackson.version>2.9.8</jackson.version>
     <!-- END: AWS jdk version + dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
     <spring-platform.version>2.0.8.RELEASE</spring-platform.version>
     <!-- BEGIN: AWS jdk version + dependencies -->
-    <aws-jdk.version>1.11.503</aws-jdk.version>
+    <aws-jdk.version>1.11.505</aws-jdk.version>
     <httpcomponents.httpclient.version>4.5.5</httpcomponents.httpclient.version>
     <jackson.version>2.9.8</jackson.version>
     <!-- END: AWS jdk version + dependencies -->


### PR DESCRIPTION
Fixes [issue 102](https://github.com/HotelsDotCom/circus-train/issues/102).

AWS has deprecated the constructors of `AmazonSNSAsyncClient` in preference for a builder pattern. The builder returns an async client which no longer exposes the underlying executor, `AmazonSNSAsync`. This means that `awaitTermination()` can no longer be used for a graceful shutdown. However, this seems to be okay as the client is only used to publish synchronously thus the executor isn't used.