### PR TITLE
Updates for S3S3copier retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ If data is being replicated from S3 to S3 then Circus Train will use the AWS S3 
 |`copier-options.s3-server-side-encryption`|No|Whether to enable server side encryption. Defaults to `false`.|
 |`copier-options.canned-acl`|No|AWS Canned ACL name. See [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for possible values. If not specified `S3S3Copier` will not specify any canned ACL.|
 |`copier-options.copier-factory-class`|No|Controls which copier is used for replication if provided.|
-|`copier-options.s3s3copier-retry-maxattempts`|No|Controls the maximum number of attempts if AWS throws an error during copy. Default value is 3.|
+|`copier-options.s3s3-retry-max-copy-attempts`|No|Controls the maximum number of attempts if AWS throws an error during copy. Default value is 3.|
 
 ### S3 Secret Configuration
 When configuring a job for replication to or from S3, the AWS access key and secret key with read/write access to the configured S3 buckets must be supplied. To protect these from being exposed in the job's Hadoop configuration, Circus Train expects them to be stored using the Hadoop Credential Provider and the JCEKS URL provided in the Circus Train configuration `security.credential-provider` property. This property is only required if a specific set of credentials is needed or if Circus Train runs on a non-AWS environment. If it is not set then the credentials of the instance where Circus Train runs will be used - note this scenario is only valid when Circus Train is executed on an AWS environment, i.e. EC2/EMR instance.

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-with-no-partitions-mirror.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-with-no-partitions-mirror.yml
@@ -9,4 +9,4 @@ table-replications:
 security:
   credential-provider: jceks://file/${config-location}/aws.jceks
 copier-options:
-  s3s3copier-retry-maxattempts: 3
+  s3s3-retry-max-copy-attempts: 3

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-s3-s3-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-s3-s3-replication.yml
@@ -8,4 +8,4 @@ table-replications:
 security:
   credential-provider: jceks://file/${config-location}/aws.jceks
 copier-options:
-  s3s3copier-retry-maxattempts: 3
+  s3s3-retry-max-copy-attempts: 3

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3Copier.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3Copier.java
@@ -237,7 +237,7 @@ public class S3S3Copier implements Copier {
               .info("Replicating...': {}% complete",
                   String.format("%.0f", (alreadyReplicated / (double) totalBytesToReplicate) * 100.0));
         }
-      } catch (InterruptedException e) {
+      } catch (InterruptedException | AmazonClientException e) {
         throw new CircusTrainException(e);
       }
     }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptions.java
@@ -58,7 +58,7 @@ public class S3S3CopierOptions {
     /**
      * Number of copy attempts to allow when copying from S3 to S3. Default value is 3.
      */
-    MAX_COPY_ATTEMPTS("s3s3copier-retry-maxattempts");
+    MAX_COPY_ATTEMPTS("s3s3-retry-max-copy-attempts");
 
     private final String keyName;
 

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/aws/RetryableTransferManager.java
@@ -37,8 +37,8 @@ import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 public class RetryableTransferManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(RetryableTransferManager.class);
-  private static final int INITIAL_RETRY_INTERVAL_MS = 500;
-  private static final int MAX_RETRY_INTERVAL_MS = 1000;
+  private static final int INITIAL_RETRY_INTERVAL_MS = 2000;
+  private static final int MAX_RETRY_INTERVAL_MS = 6000;
 
   private RetryTemplate retryTemplate;
   private TransferManager transferManager;


### PR DESCRIPTION
Original issue [issue 56](https://github.com/HotelsDotCom/circus-train/issues/56).

This update addresses a few issues with the s3 to s3 copy retry mechanism added in [pull request 119](https://github.com/HotelsDotCom/circus-train/pull/119):

1. The configurable option for the number of max number of attempts has been renamed to `s3s3-retry-max-copy-attempts` for consistency with other options
2. The initial and max retry intervals have been increased
3. `AmazonClientException` is now being caught when `Copy.waitForCompletion()` is called to help clarify if the bug occurs here