### PR TITLE
Fixing a bug with avro transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The table below describes all the available configuration values for Circus Trai
 |`table-replications[n].source-table.partition-filter`|No|A filter to select which partitions to replicate. Used for partitioned tables only. See [Partition filters](#partition-filters) for more information.|
 |`table-replications[n].source-table.generate-partition-filter`|No|Set to `true` to enable the "Hive Diff" feature. See [Partition filter generation](#partition-filter-generation) for details. Default is `false`. If `true` the `table-replications[n].source-table.partition-filter` will be ignored and instead a generated filter will be used.|
 |`table-replications[n].source-table.partition-limit`|No|A limit on the number of partitions that will be replicated. Used for partitioned tables only.|
-|`table-replications[n].replica-table.table-location`|Yes|The base path of the replica table (fully qualified URI).|
+|`table-replications[n].replica-table.table-location`|Yes|The base path of the replica table (fully qualified URI). Please note this is a required parameter only if the `replication-mode` is `FULL`|
 |`table-replications[n].replica-table.database-name`|No|The name of the destination database in which to replicate the table. Defaults to source database name.|
 |`table-replications[n].replica-table.table-name`|No|The name of the table at the destination. Defaults to source table name.|
 |`table-replications[n].copier-options`|No|Table specific `Copier` options which override any global options. See [Copier options](#copier-options) for details.|

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
@@ -47,7 +47,7 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
   }
 
   protected boolean avroTransformationSpecified() {
-    return argsPresent(getEventId());
+    return argsPresent(getAvroSchemaDestinationFolder(), getEventId());
   }
 
   protected String getAvroSchemaDestinationFolder() {

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
@@ -90,6 +90,18 @@ public class AvroSerDeTableTransformationTest {
   }
 
   @Test
+  public void missingReplicaTableLocation() {
+    // This happens when replication mode is METADATA_UPDATE or METADATA_MIRROR
+    EventReplicaTable eventReplicaTable = new EventReplicaTable("db", "table", null);
+    when(tableReplicationEvent.getReplicaTable()).thenReturn(eventReplicaTable);
+    transformation.tableReplicationStart(tableReplicationEvent, "eventId");
+
+    transformation.transform(table);
+    verifyZeroInteractions(schemaCopier);
+    assertThat(table, is(newTable()));
+  }
+
+  @Test
   public void transformNoSourceUrl() throws Exception {
     when(avroSerDeConfig.getBaseUrl()).thenReturn("schema");
     EventReplicaTable eventReplicaTable = new EventReplicaTable("db", "table", "location");


### PR DESCRIPTION
In https://github.com/HotelsDotCom/circus-train/pull/141, I removed a `null check` for table location from `AbstractAvroSerDeTransformation.java`. Turns out that null check was unintentionally preventing the transform from getting triggered for METADATA_UPDATE and METADATA_MIRROR replication modes. This is a different bug in CT but removing that `null check` leads to integration test failures. So, I am putting that back in plus I am adding a line to the description of `replica-table location` parameter specifying that its required only `replication-mode` is `FULL`.