### PR TITLE
Section added to README.md giving a high level of Circus Train extens…

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,11 +676,13 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 
 #### Circus Train DataSqueeze Copier
 This extension implements new Copiers for Circus Train which integrate DataSqueeze.
-(https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze)
+
+https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze
 
 #### circus-train-bigquery
 This Circus Train plugin enables the conversion of BigQuery tables to Hive.
-(https://github.com/HotelsDotCom/circus-train-bigquery)
+
+https://github.com/HotelsDotCom/circus-train-bigquery
 
 ### Loading Extensions
 Circus Train loads extensions using Spring's standard [ComponentScan](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ComponentScan.html) mechanism. Users can add their own packages to be scanned by declaring `extension-packages` as a comma separated list of package names to their YAML.

--- a/README.md
+++ b/README.md
@@ -672,6 +672,16 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 * `LocationManagers` look after the source and replica locations and are an ideal point to implement both snapshot isolation and retired data clean-up.
 * `CompositeCopierFactory` allows the provision of multiple copiers for the same table in order to add functionality to the copy process, e.g. introduce compaction, copy to multiple destinations, etc.
 
+### External Extensions
+
+#### Circus Train DataSqueeze Copier
+This extension implements new Copiers for Circus Train which integrate DataSqueeze.
+(https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze)
+
+#### circus-train-bigquery
+This Circus Train plugin enables the conversion of BigQuery tables to Hive.
+(https://github.com/HotelsDotCom/circus-train-bigquery)
+
 ### Loading Extensions
 Circus Train loads extensions using Spring's standard [ComponentScan](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ComponentScan.html) mechanism. Users can add their own packages to be scanned by declaring `extension-packages` as a comma separated list of package names to their YAML.
 
@@ -895,16 +905,6 @@ Note that the Circus Train configuration only supports one set of AWS credential
           database-name: aws-a_db
           table-name: aws-a_table
           table-location: s3://<aws-a-data-bucket>/<pata-to-aws-a_db>/aws-a_table
-
-## Circus Train extensions
-
-### Circus Train DataSqueeze Copier
-This extension implements new Copiers for Circus Train which integrate DataSqueeze.
-(https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze)
-
-### circus-train-bigquery
-This Circus Train plugin enables the conversion of BigQuery tables to Hive.
-(https://github.com/HotelsDotCom/circus-train-bigquery)
 
 # Contact
 

--- a/README.md
+++ b/README.md
@@ -900,11 +900,11 @@ Note that the Circus Train configuration only supports one set of AWS credential
 
 ### Circus Train DataSqueeze Copier
 This extension implements new Copiers for Circus Train which integrate DataSqueeze.
-url: https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze
+(https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze)
 
 ### circus-train-bigquery
 This Circus Train plugin enables the conversion of BigQuery tables to Hive.
-url: https://github.com/HotelsDotCom/circus-train-bigquery
+(https://github.com/HotelsDotCom/circus-train-bigquery)
 
 # Contact
 

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 The [DataSqueeze](https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze) extension provides new Copiers for Circus Train which compact the data being replicated in various ways
 
 #### circus-train-bigquery
-[The Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive
+The [Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive
 
 ### Loading Extensions
 Circus Train loads extensions using Spring's standard [ComponentScan](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ComponentScan.html) mechanism. Users can add their own packages to be scanned by declaring `extension-packages` as a comma separated list of package names to their YAML.

--- a/README.md
+++ b/README.md
@@ -896,6 +896,16 @@ Note that the Circus Train configuration only supports one set of AWS credential
           table-name: aws-a_table
           table-location: s3://<aws-a-data-bucket>/<pata-to-aws-a_db>/aws-a_table
 
+## Circus Train extensions
+
+### Circus Train DataSqueeze Copier
+This extension implements new Copiers for Circus Train which integrate DataSqueeze.
+url: https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze
+
+### circus-train-bigquery
+This Circus Train plugin enables the conversion of BigQuery tables to Hive.
+url: https://github.com/HotelsDotCom/circus-train-bigquery
+
 # Contact
 
 ## Mailing List

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 #### Circus Train DataSqueeze Copier
 The [DataSqueeze](https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze) extension provides new Copiers for Circus Train which compact the data being replicated in various ways.
 
-#### circus-train-bigquery
+#### Circus Train BigQuery To Hive Replication
 The [Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive.
 
 ### Loading Extensions

--- a/README.md
+++ b/README.md
@@ -675,10 +675,10 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 ### External Extensions
 
 #### Circus Train DataSqueeze Copier
-The [DataSqueeze](https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze) extension provides new Copiers for Circus Train which compact the data being replicated in various ways
+The [DataSqueeze](https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze) extension provides new Copiers for Circus Train which compact the data being replicated in various ways.
 
 #### circus-train-bigquery
-The [Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive
+The [Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive.
 
 ### Loading Extensions
 Circus Train loads extensions using Spring's standard [ComponentScan](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ComponentScan.html) mechanism. Users can add their own packages to be scanned by declaring `extension-packages` as a comma separated list of package names to their YAML.

--- a/README.md
+++ b/README.md
@@ -675,14 +675,10 @@ Circus Train can be extended in various ways. This is an advanced feature that t
 ### External Extensions
 
 #### Circus Train DataSqueeze Copier
-This extension implements new Copiers for Circus Train which integrate DataSqueeze.
-
-https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze
+The [DataSqueeze](https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze) extension provides new Copiers for Circus Train which compact the data being replicated in various ways
 
 #### circus-train-bigquery
-This Circus Train plugin enables the conversion of BigQuery tables to Hive.
-
-https://github.com/HotelsDotCom/circus-train-bigquery
+[The Circus Train BigQuery](https://github.com/HotelsDotCom/circus-train-bigquery) extension enables the conversion of Google BigQuery tables to Hive
 
 ### Loading Extensions
 Circus Train loads extensions using Spring's standard [ComponentScan](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ComponentScan.html) mechanism. Users can add their own packages to be scanned by declaring `extension-packages` as a comma separated list of package names to their YAML.


### PR DESCRIPTION
Section added to README.md giving a high level of Circus Train extensions that are publicly available, namely

https://github.com/ExpediaInceCommercePlatform/circus-train-datasqueeze
https://github.com/HotelsDotCom/circus-train-bigquery