### PR TITLE
Added TemporaryAWSCredentialsProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 * Table transformation to add custom properties to tables during a replication.
 * If a user doesn't specify `avro-serde-options`, Circus Train will still copy the external schema over to the target table. See [#131](https://github.com/HotelsDotCom/circus-train/issues/131).
+* `TemporaryAWSCredentialsProvider` to the `HadoopAWSCredentialProviderChain`.
 
 ### Removed
 * Excluded `org.pentaho:pentaho-aggdesigner-algorithm` from build.

--- a/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/HadoopAWSCredentialProviderChain.java
+++ b/circus-train-aws/src/main/java/com/hotels/bdp/circustrain/aws/HadoopAWSCredentialProviderChain.java
@@ -16,6 +16,7 @@
 package com.hotels.bdp.circustrain.aws;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
@@ -42,7 +43,8 @@ public class HadoopAWSCredentialProviderChain extends AWSCredentialsProviderChai
   }
 
   public HadoopAWSCredentialProviderChain(Configuration conf) {
-    super(new JceksAWSCredentialProvider(conf), new EC2ContainerCredentialsProviderWrapper());
+    super(new JceksAWSCredentialProvider(conf), new TemporaryAWSCredentialsProvider(null, conf),
+        new EC2ContainerCredentialsProviderWrapper());
   }
 
 }


### PR DESCRIPTION
Waiting with merging for some testing.
This hopefully allows users to set per bucket credentials in the core-site.xml and CT will pick up those changes when doing s3MapReduceCopies.