### PR TITLE
Reusing copier for AVRO schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## TBD - TBD
 ### Changed
-* Change the way the AVRO Schema Copier works, reusing normal 'data' copier. See [#162](https://github.com/HotelsDotCom/circus-train/issues/162). 
+* AVRO Schema Copier now re-uses the normal 'data' copier instead of its own. See [#162](https://github.com/HotelsDotCom/circus-train/issues/162). 
 
 ## [15.0.0] - 2019-11-12
 ### Changed
@@ -373,4 +373,3 @@ _New configuration file_
 # 1.5.1
 
 * `DistCP` temporary path is now set per task.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## [15.1.0] - TBD
 ### Changed
 * AVRO Schema Copier now re-uses the normal 'data' copier instead of its own. See [#162](https://github.com/HotelsDotCom/circus-train/issues/162). 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## [15.0.0] - 2019-11-12
+## TBD - TBD
+### Changed
+* Change the way the AVRO Schema Copier works, reusing normal 'data' copier. See [#162](https://github.com/HotelsDotCom/circus-train/issues/162). 
 
+## [15.0.0] - 2019-11-12
 ### Changed
 * Default `avro-serde-options` must now be included within `transform-options`. This is a backwards incompatible change to the configuration file. Please see [Avro Schema Replication](https://github.com/HotelsDotCom/circus-train/blob/master/circus-train-avro/README.md) for more information.
 * Updated `jackson` version to 2.10.0 (was 2.9.10).
@@ -12,7 +15,6 @@
 * Added `copier-options.assume-role` to assume a role when using the S3S3 copier.  
 
 ## [14.1.0] - 2019-10-04
-
 ### Added
 * Table transformation to add custom properties to tables during a replication.
 * If a user doesn't specify `avro-serde-options`, Circus Train will still copy the external schema over to the target table. See [#131](https://github.com/HotelsDotCom/circus-train/issues/131).

--- a/circus-train-api/pom.xml
+++ b/circus-train-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-api</artifactId>

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/conf/TableReplication.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/conf/TableReplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
+import com.google.common.collect.ImmutableMap;
 
 import com.hotels.bdp.circustrain.api.validation.constraints.TableReplicationFullReplicationModeConstraint;
 
@@ -57,6 +59,23 @@ public class TableReplication {
 
   public Map<String, Object> getCopierOptions() {
     return copierOptions;
+  }
+
+  public Map<String, Object> getMergedCopierOptions(Map<String, Object> baseCopierOptions) {
+    return getMergedCopierOptions(baseCopierOptions, getCopierOptions());
+  }
+
+  public static Map<String, Object> getMergedCopierOptions(
+      Map<String, Object> baseCopierOptions,
+      Map<String, Object> overrideCopierOptions) {
+    Map<String, Object> mergedCopierOptions = new HashMap<>();
+    if (baseCopierOptions != null) {
+      mergedCopierOptions.putAll(baseCopierOptions);
+    }
+    if (overrideCopierOptions != null) {
+      mergedCopierOptions.putAll(overrideCopierOptions);
+    }
+    return ImmutableMap.copyOf(mergedCopierOptions);
   }
 
   public void setCopierOptions(Map<String, Object> copierOptions) {

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactoryManager.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactoryManager.java
@@ -17,14 +17,9 @@ package com.hotels.bdp.circustrain.api.copier;
 
 import java.util.Map;
 
-public interface CopierOptions {
+import org.apache.hadoop.fs.Path;
 
-  String IGNORE_MISSING_PARTITION_FOLDER_ERRORS = "ignore-missing-partition-folder-errors";
+public interface CopierFactoryManager {
 
-  // internal option used to track if the destination of the replication should be treated as a folder or file. Value
-  // can be parsed with Boolean.parseValue. If not set a folder is assumed.
-  String COPY_DESTINATION_IS_FILE = "copy-destination-is-file";
-
-  Map<String, Object> getCopierOptions();
-
+  CopierFactory getCopierFactory(Path sourceLocation, Path replicaLocation, Map<String, Object> copierOptions);
 }

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/TableReplicationTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/TableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 package com.hotels.bdp.circustrain.api.conf;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -87,6 +91,28 @@ public class TableReplicationTest {
     Set<ConstraintViolation<TableReplication>> violations = validator.validate(tableReplication);
 
     assertThat(violations.size(), is(1));
+  }
+
+  @Test
+  public void mergeNullOptions() {
+    Map<String, Object> mergedCopierOptions = tableReplication.getMergedCopierOptions(null);
+    assertThat(mergedCopierOptions, is(not(nullValue())));
+    assertThat(mergedCopierOptions.isEmpty(), is(true));
+  }
+
+  @Test
+  public void mergeOptions() {
+    Map<String, Object> globalOptions = new HashMap<>();
+    globalOptions.put("one", Integer.valueOf(1));
+    globalOptions.put("two", Integer.valueOf(2));
+    Map<String, Object> overrideOptions = new HashMap<>();
+    overrideOptions.put("two", "two");
+    overrideOptions.put("three", "three");
+    tableReplication.setCopierOptions(overrideOptions);
+    Map<String, Object> mergedCopierOptions = tableReplication.getMergedCopierOptions(globalOptions);
+    assertThat((Integer) mergedCopierOptions.get("one"), is(Integer.valueOf(1)));
+    assertThat((String) mergedCopierOptions.get("two"), is("two"));
+    assertThat((String) mergedCopierOptions.get("three"), is("three"));
   }
 
 }

--- a/circus-train-avro/pom.xml
+++ b/circus-train-avro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-avro</artifactId>

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
@@ -91,15 +91,8 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
   }
 
   @Override
-  public void tableReplicationSuccess(EventTableReplication tableReplication, String eventId) {
-    this.eventId = null;
-    this.tableReplication = null;
-  }
+  public void tableReplicationSuccess(EventTableReplication tableReplication, String eventId) {}
 
   @Override
-  public void tableReplicationFailure(EventTableReplication tableReplication, String eventId, Throwable t) {
-    this.eventId = null;
-    this.tableReplication = null;
-
-  }
+  public void tableReplicationFailure(EventTableReplication tableReplication, String eventId, Throwable t) {}
 }

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
   private String eventId;
   private String tableLocation;
   private Map<String, Object> avroSerdeConfigOverride = Collections.emptyMap();
+  private EventTableReplication tableReplication;
   static final String AVRO_SCHEMA_URL_PARAMETER = "avro.schema.url";
 
   protected AbstractAvroSerDeTransformation(TransformOptions transformOptions) {
@@ -50,6 +51,10 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
 
   protected String getEventId() {
     return eventId;
+  }
+
+  protected EventTableReplication getTableReplication() {
+    return tableReplication;
   }
 
   protected String getTableLocation() {
@@ -75,6 +80,7 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
   @Override
   public void tableReplicationStart(EventTableReplication tableReplication, String eventId) {
     this.eventId = eventId;
+    this.tableReplication = tableReplication;
     tableLocation = tableReplication.getReplicaTable().getTableLocation();
     avroSerdeConfigOverride = Collections.emptyMap();
     Map<String, Object> transformOptions = tableReplication.getTransformOptions();
@@ -85,8 +91,15 @@ public abstract class AbstractAvroSerDeTransformation implements TableReplicatio
   }
 
   @Override
-  public void tableReplicationSuccess(EventTableReplication tableReplication, String eventId) {}
+  public void tableReplicationSuccess(EventTableReplication tableReplication, String eventId) {
+    this.eventId = null;
+    this.tableReplication = null;
+  }
 
   @Override
-  public void tableReplicationFailure(EventTableReplication tableReplication, String eventId, Throwable t) {}
+  public void tableReplicationFailure(EventTableReplication tableReplication, String eventId, Throwable t) {
+    this.eventId = null;
+    this.tableReplication = null;
+
+  }
 }

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformation.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,9 @@ public class AvroSerDePartitionTransformation extends AbstractAvroSerDeTransform
   private Partition apply(Partition partition, String avroSchemaDestination) {
     String source = HiveObjectUtils.getParameter(partition, AVRO_SCHEMA_URL_PARAMETER);
     if (argsPresent(source, avroSchemaDestination)) {
-      String destinationPath = copier.copy(source, avroSchemaDestination).toString();
+      String destinationPath = copier
+          .copy(source, avroSchemaDestination, getTableReplication(), getEventId())
+          .toString();
       HiveObjectUtils.updateSerDeUrl(partition, AVRO_SCHEMA_URL_PARAMETER, destinationPath);
     }
     return partition;

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformation.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,9 @@ public final class AvroSerDeTableTransformation extends AbstractAvroSerDeTransfo
   private Table apply(Table table, String avroSchemaDestination) {
     String source = HiveObjectUtils.getParameter(table, AVRO_SCHEMA_URL_PARAMETER);
     if (argsPresent(source, avroSchemaDestination)) {
-      String destinationPath = copier.copy(source, avroSchemaDestination).toString();
+      String destinationPath = copier
+          .copy(source, avroSchemaDestination, getTableReplication(), getEventId())
+          .toString();
       HiveObjectUtils.updateSerDeUrl(table, AVRO_SCHEMA_URL_PARAMETER, destinationPath);
     }
     return table;

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtils.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,30 +37,6 @@ public final class AvroStringUtils {
       return pathToDestinationFolder + eventId + ".schema";
     }
     return pathToDestinationFolder + eventId;
-  }
-
-  public static String fileName(String pathToFile) {
-    checkArgument(isNotBlank(pathToFile), "There must be a pathToFile provided");
-    if (pathToFile.charAt(pathToFile.length() - 1) == '/') {
-      pathToFile = pathToFile.substring(0, pathToFile.length() - 1);
-    }
-
-    String fileName = pathToFile.substring(pathToFile.lastIndexOf("/") + 1, pathToFile.length());
-    if (countPeriods(fileName) != 1) {
-      throw new IllegalArgumentException("Incorrect fileName " + fileName);
-    }
-
-    return fileName;
-  }
-
-  private static int countPeriods(String string) {
-    int periodCount = 0;
-    for (int i = 0; i < string.length(); i++) {
-      if (string.charAt(i) == '.') {
-        periodCount++;
-      }
-    }
-    return periodCount;
   }
 
   public static boolean argsPresent(String... args) {

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
@@ -35,6 +35,8 @@ import com.hotels.bdp.circustrain.api.CircusTrainException;
 public class FileSystemPathResolver {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemPathResolver.class);
 
+  private static final String HDFS_SCHEME = "hdfs";
+
   private final Configuration configuration;
 
   public FileSystemPathResolver(Configuration configuration) {
@@ -58,7 +60,7 @@ public class FileSystemPathResolver {
   }
 
   public Path resolveNameServices(Path path) {
-    if ("hdfs".equalsIgnoreCase(path.toUri().getScheme())) {
+    if (HDFS_SCHEME.equalsIgnoreCase(path.toUri().getScheme())) {
       String nameService = configuration.get(DFSConfigKeys.DFS_NAMESERVICES);
       if (isNotBlank(nameService)) {
         URI uri = path.toUri();

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
@@ -60,10 +60,10 @@ public class FileSystemPathResolver {
   }
 
   public Path resolveNameServices(Path path) {
-    if (HDFS_SCHEME.equalsIgnoreCase(path.toUri().getScheme())) {
+    URI uri = path.toUri();
+    if (HDFS_SCHEME.equalsIgnoreCase(uri.getScheme())) {
       String nameService = configuration.get(DFSConfigKeys.DFS_NAMESERVICES);
       if (isNotBlank(nameService)) {
-        URI uri = path.toUri();
         String scheme = uri.getScheme();
         String url = uri.getPath();
         final String original = path.toString();

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolver.java
@@ -58,21 +58,22 @@ public class FileSystemPathResolver {
   }
 
   public Path resolveNameServices(Path path) {
-    String nameService = configuration.get(DFSConfigKeys.DFS_NAMESERVICES);
-    if (isNotBlank(nameService)) {
-      URI uri = path.toUri();
-      String scheme = uri.getScheme();
-      String url = uri.getPath();
-      final String original = path.toString();
-      if (isBlank(scheme)) {
-        url = String.format("/%s%s", nameService, path);
-        path = new Path(url);
-      } else {
-        path = new Path(scheme, nameService, url);
+    if ("hdfs".equalsIgnoreCase(path.toUri().getScheme())) {
+      String nameService = configuration.get(DFSConfigKeys.DFS_NAMESERVICES);
+      if (isNotBlank(nameService)) {
+        URI uri = path.toUri();
+        String scheme = uri.getScheme();
+        String url = uri.getPath();
+        final String original = path.toString();
+        if (isBlank(scheme)) {
+          url = String.format("/%s%s", nameService, path);
+          path = new Path(url);
+        } else {
+          path = new Path(scheme, nameService, url);
+        }
+        LOG.info("Added nameservice to path. {} became {}", original, path);
       }
-      LOG.info("Added nameservice to path. {} became {}", original, path);
     }
-
     return path;
   }
 

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
@@ -68,7 +68,7 @@ public class SchemaCopier {
 
     Path destinationSchemaFile = new Path(destination, sourceLocation.getName());
 
-    Map<String, Object> mergeCopierOptions = new HashMap<>(TableReplication
+    Map<String, Object> mergedCopierOptions = new HashMap<>(TableReplication
         .getMergedCopierOptions(globalCopierOptions.getCopierOptions(), eventTableReplication.getCopierOptions()));
     mergeCopierOptions.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
     CopierFactory copierFactory = copierFactoryManager

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
@@ -70,11 +70,11 @@ public class SchemaCopier {
 
     Map<String, Object> mergedCopierOptions = new HashMap<>(TableReplication
         .getMergedCopierOptions(globalCopierOptions.getCopierOptions(), eventTableReplication.getCopierOptions()));
-    mergeCopierOptions.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
+    mergedCopierOptions.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
     CopierFactory copierFactory = copierFactoryManager
-        .getCopierFactory(sourceLocation, destinationSchemaFile, mergeCopierOptions);
+        .getCopierFactory(sourceLocation, destinationSchemaFile, mergedCopierOptions);
     LOG.info("Going to replicate the Avro schema from '{}' to '{}'", sourceLocation, destinationSchemaFile);
-    Copier copier = copierFactory.newInstance(eventId, sourceLocation, destinationSchemaFile, mergeCopierOptions);
+    Copier copier = copierFactory.newInstance(eventId, sourceLocation, destinationSchemaFile, mergedCopierOptions);
     Metrics metrics = copier.copy();
 
     LOG

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ public class AbstractAvroSerDeTransformationTest {
     runLifeCycleSuccess(tableReplication);
     assertThat(transformation.getAvroSchemaDestinationFolder(), is("overrideBaseUrl"));
     assertThat(transformation.getEventId(), is(EVENT_ID));
+    assertThat(transformation.getTableReplication(), is(tableReplication));
     assertThat(transformation.getTableLocation(), is(TABLE_LOCATION));
   }
 
@@ -79,11 +80,13 @@ public class AbstractAvroSerDeTransformationTest {
     runLifeCycleSuccess(tableReplication);
     assertThat(transformation.getAvroSchemaDestinationFolder(), is("overrideBaseUrl"));
     assertThat(transformation.getEventId(), is(EVENT_ID));
+    assertThat(transformation.getTableReplication(), is(tableReplication));
     assertThat(transformation.getTableLocation(), is(TABLE_LOCATION));
     EventTableReplication tableReplication2 = mockTableReplication("overrideBaseUrl2");
     runLifeCycleSuccess(tableReplication2);
     assertThat(transformation.getAvroSchemaDestinationFolder(), is("overrideBaseUrl2"));
     assertThat(transformation.getEventId(), is(EVENT_ID));
+    assertThat(transformation.getTableReplication(), is(tableReplication2));
     assertThat(transformation.getTableLocation(), is(TABLE_LOCATION));
   }
 
@@ -108,6 +111,7 @@ public class AbstractAvroSerDeTransformationTest {
     assertThat(transformation.getAvroSchemaDestinationFolder(), is("overrideBaseUrl"));
     assertThat(transformation.getEventId(), is(EVENT_ID));
     assertThat(transformation.getTableLocation(), is(TABLE_LOCATION));
+    assertThat(transformation.getTableReplication(), is(tableReplication));
   }
 
   @Test
@@ -116,11 +120,13 @@ public class AbstractAvroSerDeTransformationTest {
     runLifeCycleSuccess(tableReplication);
     assertThat("overrideBaseUrl", is(transformation.getAvroSchemaDestinationFolder()));
     assertThat(EVENT_ID, is(transformation.getEventId()));
+    assertThat(transformation.getTableReplication(), is(tableReplication));
     assertThat(TABLE_LOCATION, is(transformation.getTableLocation()));
     EventTableReplication tableReplication2 = mockTableReplication("overrideBaseUrl2");
     runLifeCycleFailure(tableReplication2);
     assertThat(transformation.getAvroSchemaDestinationFolder(), is("overrideBaseUrl2"));
     assertThat(transformation.getEventId(), is(EVENT_ID));
+    assertThat(transformation.getTableReplication(), is(tableReplication2));
     assertThat(transformation.getTableLocation(), is(TABLE_LOCATION));
   }
 
@@ -139,7 +145,7 @@ public class AbstractAvroSerDeTransformationTest {
   }
 
   @Test
-  public void testReplicationOverrideNullTransformOptions() {;
+  public void testReplicationOverrideNullTransformOptions() {
     transformation = new DummyAvroSerDeTransformation(new TransformOptions());
     EventTableReplication tableReplication = mockTableReplication("overrideBaseUrl");
     runLifeCycleSuccess(tableReplication);
@@ -150,7 +156,7 @@ public class AbstractAvroSerDeTransformationTest {
   }
 
   @Test
-  public void testNullTransformOptions() {;
+  public void testNullTransformOptions() {
     transformation = new DummyAvroSerDeTransformation(new TransformOptions());
     EventTableReplication tableReplication = mockTableReplication(null);
     runLifeCycleSuccess(tableReplication);

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,8 @@ public class AvroSerDePartitionTransformationTest {
     transformation.tableReplicationStart(tableReplicationEvent, "eventId");
     HiveObjectUtils.updateSerDeUrl(partition, AVRO_SCHEMA_URL_PARAMETER, "avroSourceUrl");
 
-    when(schemaCopier.copy("avroSourceUrl", "schema/eventId/")).thenReturn(destinationPath);
+    when(schemaCopier.copy("avroSourceUrl", "schema/eventId/", tableReplicationEvent, "eventId"))
+        .thenReturn(destinationPath);
     Partition result = transformation.transform(partition);
     assertThat(result.getParameters().get(AVRO_SCHEMA_URL_PARAMETER), is(destinationPathString));
   }
@@ -129,7 +130,8 @@ public class AvroSerDePartitionTransformationTest {
     transformation.tableReplicationStart(tableReplicationEvent, "eventId");
 
     HiveObjectUtils.updateSerDeUrl(partition, AVRO_SCHEMA_URL_PARAMETER, "avroSourceUrl");
-    when(schemaCopier.copy("avroSourceUrl", "schemaOverride/eventId/")).thenReturn(destinationPath);
+    when(schemaCopier.copy("avroSourceUrl", "schemaOverride/eventId/", tableReplicationEvent, "eventId"))
+        .thenReturn(destinationPath);
 
     Partition result = transformation.transform(partition);
     assertThat(result.getParameters().get(AVRO_SCHEMA_URL_PARAMETER), is(destinationPathString));

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class AvroSerDeTableTransformationTest {
 
   private static final String AVRO_SCHEMA_URL_PARAMETER = "avro.schema.url";
 
-  private TransformOptions transformOptions = new TransformOptions();
+  private final TransformOptions transformOptions = new TransformOptions();
 
   @Mock
   private SchemaCopier schemaCopier;
@@ -123,7 +123,8 @@ public class AvroSerDeTableTransformationTest {
     EventReplicaTable eventReplicaTable = new EventReplicaTable("db", "table", "location");
     when(tableReplicationEvent.getReplicaTable()).thenReturn(eventReplicaTable);
     HiveObjectUtils.updateSerDeUrl(table, AVRO_SCHEMA_URL_PARAMETER, "avroSourceUrl");
-    when(schemaCopier.copy("avroSourceUrl", "location/eventId/.schema")).thenReturn(destinationPath);
+    when(schemaCopier.copy("avroSourceUrl", "location/eventId/.schema", tableReplicationEvent, "eventId"))
+        .thenReturn(destinationPath);
 
     transformation = new AvroSerDeTableTransformation(new TransformOptions(), schemaCopier);
     transformation.tableReplicationStart(tableReplicationEvent, "eventId");
@@ -136,7 +137,8 @@ public class AvroSerDeTableTransformationTest {
     EventReplicaTable eventReplicaTable = new EventReplicaTable("db", "table", "location");
     when(tableReplicationEvent.getReplicaTable()).thenReturn(eventReplicaTable);
     HiveObjectUtils.updateSerDeUrl(table, AVRO_SCHEMA_URL_PARAMETER, "avroSourceUrl");
-    when(schemaCopier.copy("avroSourceUrl", "schema/eventId/")).thenReturn(destinationPath);
+    when(schemaCopier.copy("avroSourceUrl", "schema/eventId/", tableReplicationEvent, "eventId"))
+        .thenReturn(destinationPath);
 
     transformation.tableReplicationStart(tableReplicationEvent, "eventId");
     Table result = transformation.transform(table);
@@ -155,7 +157,8 @@ public class AvroSerDeTableTransformationTest {
     transformation.tableReplicationStart(tableReplicationEvent, "eventId");
 
     HiveObjectUtils.updateSerDeUrl(table, AVRO_SCHEMA_URL_PARAMETER, "avroSourceUrl");
-    when(schemaCopier.copy("avroSourceUrl", "schemaOverride/eventId/")).thenReturn(destinationPath);
+    when(schemaCopier.copy("avroSourceUrl", "schemaOverride/eventId/", tableReplicationEvent, "eventId"))
+        .thenReturn(destinationPath);
 
     Table result = transformation.transform(table);
     assertThat(result.getParameters().get(AVRO_SCHEMA_URL_PARAMETER), is(destinationPathString));

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtilsTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import static com.hotels.bdp.circustrain.avro.util.AvroStringUtils.appendForwardSlashIfNotPresent;
 import static com.hotels.bdp.circustrain.avro.util.AvroStringUtils.argsPresent;
 import static com.hotels.bdp.circustrain.avro.util.AvroStringUtils.avroDestination;
-import static com.hotels.bdp.circustrain.avro.util.AvroStringUtils.fileName;
 
 import org.junit.Test;
 
@@ -66,40 +65,6 @@ public class AvroStringUtilsTest {
   @Test(expected = IllegalArgumentException.class)
   public void emptyEventIdParamTest() {
     avroDestination("", null, "location");
-  }
-
-  @Test
-  public void fileNameTest() {
-    String path = "file://test/path/test.avsc";
-    assertThat(fileName(path), is("test.avsc"));
-  }
-
-  @Test
-  public void fileNameTestStringEndsWithForwardSlash() {
-    String path = "file://test/path/test.avsc/";
-    assertThat(fileName(path), is("test.avsc"));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void fileNameWherePathDoesntEndInFileThrowsException() {
-    String path = "file://test/path/";
-    fileName(path);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void fileNameWithTwoPeriodsThrowsException() {
-    String path = "file://test/path/test.av.sc";
-    fileName(path);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void nullFullPathParamTest() {
-    fileName(null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void emptyFullPathParamTest() {
-    fileName("");
   }
 
   @Test

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolverTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolverTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/FileSystemPathResolverTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 
 public class FileSystemPathResolverTest {
 
-  private Configuration configuration = new Configuration();
-  private FileSystemPathResolver resolver = new FileSystemPathResolver(configuration);
+  private final Configuration configuration = new Configuration();
+  private final FileSystemPathResolver resolver = new FileSystemPathResolver(configuration);
 
   @Test
   public void resolveSchemeDoesntChangeSchemeForPathWithScheme() {
@@ -60,6 +60,14 @@ public class FileSystemPathResolverTest {
   }
 
   @Test
+  public void resolveNameServiceS3() {
+    setDfsPaths("hdp-ha");
+    Path input = new Path("s3:///etl/test/avsc/schema.avsc");
+    Path result = resolver.resolveNameServices(input);
+    assertThat(result, is(input));
+  }
+
+  @Test
   public void resolveNameServicesAddsAuthorityToFullyQualifiedPathWithScheme() {
     setDfsPaths("hdp-ha");
     Path input = new Path("hdfs:///etl/test/avsc/schema.avsc");
@@ -73,7 +81,7 @@ public class FileSystemPathResolverTest {
     setDfsPaths("foo");
     Path input = new Path("/etl/test/avsc/schema.avsc");
     Path result = resolver.resolveNameServices(input);
-    Path expected = new Path("/foo/etl/test/avsc/schema.avsc");
+    Path expected = new Path("/etl/test/avsc/schema.avsc");
     assertThat(result, is(expected));
   }
 

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
@@ -15,15 +15,16 @@
  */
 package com.hotels.bdp.circustrain.avro.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.Before;
@@ -34,9 +35,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
 import com.hotels.bdp.circustrain.api.event.EventTableReplication;
+import com.hotels.bdp.circustrain.api.metrics.Metrics;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaCopierTest {
@@ -44,76 +48,56 @@ public class SchemaCopierTest {
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private @Mock CopierFactoryManager copierFactoryManager;
+  private @Mock CopierFactory copierFactory;
   private @Mock CopierOptions copierOptions;
+  private @Mock Copier copier;
   private @Mock EventTableReplication eventTableReplication;
-  private SchemaCopier copier;
+  private SchemaCopier schemaCopier;
   private final String eventId = "eventId";
+  private @Mock Metrics metrics;
 
   @Before
   public void setUp() {
-    copier = new SchemaCopier(new HiveConf(), copierFactoryManager, copierOptions);
+    schemaCopier = new SchemaCopier(new HiveConf(), copierFactoryManager, copierOptions);
   }
 
   @Test
   public void copiedToCorrectDestination() throws IOException {
-    File source = temporaryFolder.newFile("test.txt");
+    Path source = new Path(temporaryFolder.newFile("test.txt").toURI());
     File destination = temporaryFolder.newFolder();
-    copier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);
-    FileSystem fs = new Path(destination.toString()).getFileSystem(new HiveConf());
-    assertTrue(fs.exists(new Path(destination.toString() + "/test.txt")));
-  }
-
-  @Test
-  public void copiedCorrectFile() throws IOException {
-    List<String> randomData = new ArrayList<>();
-    randomData.add("foo");
-    randomData.add("baz");
-    File source = temporaryFolder.newFile("test.txt");
-    FileUtils.writeLines(source, randomData);
-    File destination = temporaryFolder.newFolder();
-    File copy = new File(
-        copier.copy(source.toString(), destination.toString(), eventTableReplication, eventId).toString());
-    assertTrue(FileUtils.contentEquals(source, copy));
-  }
-
-  @Test
-  public void copyDoesntDeleteOriginalFile() throws IOException {
-    File source = temporaryFolder.newFile("test.txt");
-    File destination = temporaryFolder.newFolder();
-    copier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);
-    FileSystem fs = new Path(destination.toString()).getFileSystem(new HiveConf());
-    assertTrue(fs.exists(new Path(source.toString())));
-  }
-
-  @Test
-  public void copiedFileAndNotDirectory() throws IOException {
-    File source = temporaryFolder.newFile("test.txt");
-    File destination = temporaryFolder.newFolder();
-    copier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);
-    assertTrue(new File(destination.toString() + "/test.txt").isFile());
+    Path targetFile = new Path(destination.toString(), "test.txt");
+    Map<String, Object> copierOptionsMap = new HashMap<>();
+    copierOptionsMap.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
+    when(copierFactoryManager.getCopierFactory(eq(source), eq(targetFile), eq(copierOptionsMap)))
+        .thenReturn(copierFactory);
+    when(copierFactory.newInstance(eq(eventId), eq(source), eq(targetFile), eq(copierOptionsMap))).thenReturn(copier);
+    when(copier.copy()).thenReturn(metrics);
+    when(metrics.getBytesReplicated()).thenReturn(123L);
+    Path result = schemaCopier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);
+    assertThat(result, is(targetFile));
   }
 
   @Test(expected = NullPointerException.class)
   public void copyWithNullSourceParamThrowsException() throws IOException {
     File destination = temporaryFolder.newFolder();
-    copier.copy(null, destination.toString(), eventTableReplication, eventId);
+    schemaCopier.copy(null, destination.toString(), eventTableReplication, eventId);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void copyWithEmptySourceParamThrowsException() throws IOException {
     File destination = temporaryFolder.newFolder();
-    copier.copy("", destination.toString(), eventTableReplication, eventId);
+    schemaCopier.copy("", destination.toString(), eventTableReplication, eventId);
   }
 
   @Test(expected = NullPointerException.class)
   public void copyWithNullDestinationParamThrowsException() throws IOException {
     File source = temporaryFolder.newFile("test.txt");
-    copier.copy(source.toString(), null, eventTableReplication, eventId);
+    schemaCopier.copy(source.toString(), null, eventTableReplication, eventId);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void copyWithEmptyDestinationParamThrowsException() throws IOException {
     File source = temporaryFolder.newFile("test.txt");
-    copier.copy(source.toString(), "", eventTableReplication, eventId);
+    schemaCopier.copy(source.toString(), "", eventTableReplication, eventId);
   }
 }

--- a/circus-train-aws-sns/pom.xml
+++ b/circus-train-aws-sns/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/circus-train-aws/pom.xml
+++ b/circus-train-aws/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-aws</artifactId>

--- a/circus-train-common-test/pom.xml
+++ b/circus-train-common-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-common-test</artifactId>

--- a/circus-train-comparator/pom.xml
+++ b/circus-train-comparator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparator</artifactId>

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-core</artifactId>

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrain.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/CircusTrain.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 
 import com.hotels.bdp.circustrain.api.Modules;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.api.event.LocomotiveListener;
@@ -58,7 +59,6 @@ import com.hotels.bdp.circustrain.api.metrics.MetricSender;
 import com.hotels.bdp.circustrain.api.metrics.ScheduledReporterFactory;
 import com.hotels.bdp.circustrain.comparator.hive.functions.PathDigest;
 import com.hotels.bdp.circustrain.comparator.hive.functions.PathToPathMetadata;
-import com.hotels.bdp.circustrain.core.CopierFactoryManager;
 import com.hotels.bdp.circustrain.core.PartitionPredicateFactory;
 import com.hotels.bdp.circustrain.core.ReplicationFactory;
 import com.hotels.bdp.circustrain.core.ReplicationFactoryImpl;

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManager.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,15 +37,15 @@ import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 @Profile({ Modules.REPLICATION })
 @Component
 @Order(Ordered.LOWEST_PRECEDENCE)
-public class CopierFactoryManager {
+public class DefaultCopierFactoryManager implements com.hotels.bdp.circustrain.api.copier.CopierFactoryManager {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CopierFactoryManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultCopierFactoryManager.class);
   private static final String COPIER_FACTORY_CLASS = "copier-factory-class";
 
   private final List<CopierFactory> copierFactories;
 
   @Autowired
-  public CopierFactoryManager(List<CopierFactory> copierFactories) {
+  public DefaultCopierFactoryManager(List<CopierFactory> copierFactories) {
     this.copierFactories = ImmutableList.copyOf(copierFactories);
   }
 
@@ -57,7 +57,8 @@ public class CopierFactoryManager {
     }
   }
 
-  CopierFactory getCopierFactory(Path sourceLocation, Path replicaLocation, Map<String, Object> copierOptions) {
+  @Override
+  public CopierFactory getCopierFactory(Path sourceLocation, Path replicaLocation, Map<String, Object> copierOptions) {
     String sourceScheme = sourceLocation.toUri().getScheme();
     String replicaScheme = replicaLocation.toUri().getScheme();
     if (copierOptions.containsKey(COPIER_FACTORY_CLASS)) {
@@ -72,8 +73,9 @@ public class CopierFactoryManager {
       for (CopierFactory copierFactory : copierFactories) {
         final String copierFactoryClassName = copierFactory.getClass().getName();
         if (copierFactory.supportsSchemes(sourceScheme, replicaScheme)) {
-          LOG.debug("Found CopierFactory '{}' for sourceScheme '{}' and replicaScheme '{}'",
-                  copierFactoryClassName, sourceScheme, replicaScheme);
+          LOG
+              .debug("Found CopierFactory '{}' for sourceScheme '{}' and replicaScheme '{}'", copierFactoryClassName,
+                  sourceScheme, replicaScheme);
           return copierFactory;
         }
       }

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 import com.hotels.bdp.circustrain.api.util.DotJoiner;

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -47,7 +47,7 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
   public ReplicationFactoryImpl(
       SourceFactory sourceFactory,
       ReplicaFactory replicaFactory,
-      CopierFactoryManager CopierFactoryManager,
+      CopierFactoryManager copierFactoryManager,
       CopierListener copierListener,
       PartitionPredicateFactory partitionPredicateFactory,
       CopierOptions copierOptions) {

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,18 @@
  */
 package com.hotels.bdp.circustrain.core;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
 import com.hotels.bdp.circustrain.api.conf.SourceTable;
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.core.replica.Replica;
@@ -50,13 +47,13 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
   public ReplicationFactoryImpl(
       SourceFactory sourceFactory,
       ReplicaFactory replicaFactory,
-      CopierFactoryManager copierFactoryManager,
+      CopierFactoryManager CopierFactoryManager,
       CopierListener copierListener,
       PartitionPredicateFactory partitionPredicateFactory,
       CopierOptions copierOptions) {
     this.sourceFactory = sourceFactory;
     this.replicaFactory = replicaFactory;
-    this.copierFactoryManager = copierFactoryManager;
+    copierFactoryManager = CopierFactoryManager;
     this.copierListener = copierListener;
     this.partitionPredicateFactory = partitionPredicateFactory;
     this.copierOptions = copierOptions;
@@ -111,7 +108,8 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
           partitionPredicate, source, replica, eventIdFactory, replicaDatabaseName, replicaTableName);
       break;
     case FULL:
-      Map<String, Object> mergedCopierOptions = mergeCopierOptions(tableReplication.getCopierOptions());
+      Map<String, Object> mergedCopierOptions = tableReplication
+          .getMergedCopierOptions(copierOptions.getCopierOptions());
       replication = new PartitionedTableReplication(sourceDatabaseName, sourceTableName, partitionPredicate, source,
           replica, copierFactoryManager, eventIdFactory, replicaTableLocation, replicaDatabaseName, replicaTableName,
           mergedCopierOptions, copierListener);
@@ -144,7 +142,8 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
           replica, eventIdFactory, replicaDatabaseName, replicaTableName);
       break;
     case FULL:
-      Map<String, Object> mergedCopierOptions = mergeCopierOptions(tableReplication.getCopierOptions());
+      Map<String, Object> mergedCopierOptions = tableReplication
+          .getMergedCopierOptions(copierOptions.getCopierOptions());
       replication = new UnpartitionedTableReplication(sourceDatabaseName, sourceTableName, source, replica,
           copierFactoryManager, eventIdFactory, replicaTableLocation, replicaDatabaseName, replicaTableName,
           mergedCopierOptions, copierListener);
@@ -171,18 +170,6 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
           .format("Cannot replicate view %s. Only %s is supported for views",
               tableReplication.getSourceTable().getQualifiedName(), ReplicationMode.METADATA_MIRROR.name()));
     }
-  }
-
-  @VisibleForTesting
-  Map<String, Object> mergeCopierOptions(Map<String, Object> overridingCopierOptions) {
-    Map<String, Object> mergedCopierOptions = new HashMap<>();
-    if (copierOptions.getCopierOptions() != null) {
-      mergedCopierOptions.putAll(copierOptions.getCopierOptions());
-    }
-    if (overridingCopierOptions != null) {
-      mergedCopierOptions.putAll(overridingCopierOptions);
-    }
-    return ImmutableMap.copyOf(mergedCopierOptions);
   }
 
 }

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -53,7 +53,7 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
       CopierOptions copierOptions) {
     this.sourceFactory = sourceFactory;
     this.replicaFactory = replicaFactory;
-    copierFactoryManager = CopierFactoryManager;
+    this.copierFactoryManager = copierFactoryManager;
     this.copierListener = copierListener;
     this.partitionPredicateFactory = partitionPredicateFactory;
     this.copierOptions = copierOptions;

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 import com.hotels.bdp.circustrain.api.util.DotJoiner;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CopierFactoryManagerTest {
+public class DefaultCopierFactoryManagerTest {
 
   private static final String SCHEME = "scheme";
 
@@ -43,14 +43,14 @@ public class CopierFactoryManagerTest {
   @Mock
   private CopierFactory copierFactory;
 
-  private CopierFactoryManager copierFactoryManager;
+  private DefaultCopierFactoryManager defaultCopierFactoryManager;
 
   @Test
   public void supportsScheme() {
-    copierFactoryManager = new CopierFactoryManager(Arrays.asList(copierFactory));
+    defaultCopierFactoryManager = new DefaultCopierFactoryManager(Arrays.asList(copierFactory));
     when(copierFactory.supportsSchemes(SCHEME, SCHEME)).thenReturn(true);
 
-    CopierFactory copierFactoryResult = copierFactoryManager.getCopierFactory(path, path,
+    CopierFactory copierFactoryResult = defaultCopierFactoryManager.getCopierFactory(path, path,
         ImmutableMap.<String, Object> of());
 
     assertEquals(copierFactory, copierFactoryResult);
@@ -58,17 +58,17 @@ public class CopierFactoryManagerTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void doesNotSupportScheme() {
-    copierFactoryManager = new CopierFactoryManager(Arrays.asList(copierFactory));
+    defaultCopierFactoryManager = new DefaultCopierFactoryManager(Arrays.asList(copierFactory));
     when(copierFactory.supportsSchemes(SCHEME, SCHEME)).thenReturn(false);
 
-    copierFactoryManager.getCopierFactory(path, path, ImmutableMap.<String, Object> of());
+    defaultCopierFactoryManager.getCopierFactory(path, path, ImmutableMap.<String, Object> of());
   }
 
   @Test
   public void supportsSchemeWithCopierFactoryClass() {
     CopierFactory testCopierFactory = new TestCopierFactory();
-    copierFactoryManager = new CopierFactoryManager(Arrays.asList(testCopierFactory));
-    CopierFactory copierFactoryResult = copierFactoryManager.getCopierFactory(path, path,
+    defaultCopierFactoryManager = new DefaultCopierFactoryManager(Arrays.asList(testCopierFactory));
+    CopierFactory copierFactoryResult = defaultCopierFactoryManager.getCopierFactory(path, path,
         ImmutableMap.<String, Object> of("copier-factory-class", testCopierFactory.getClass().getName()));
 
     assertEquals(copierFactoryResult, testCopierFactory);
@@ -77,9 +77,9 @@ public class CopierFactoryManagerTest {
   @Test(expected = UnsupportedOperationException.class)
   public void supportsSchemeWithCopierFactoryClassNotFound() {
     CopierFactory testCopierFactory = new TestCopierFactory();
-    copierFactoryManager = new CopierFactoryManager(Arrays.asList(testCopierFactory));
+    defaultCopierFactoryManager = new DefaultCopierFactoryManager(Arrays.asList(testCopierFactory));
 
-    copierFactoryManager.getCopierFactory(path, path, ImmutableMap.<String, Object> of("copier-factory-class", "test"));
+    defaultCopierFactoryManager.getCopierFactory(path, path, ImmutableMap.<String, Object> of("copier-factory-class", "test"));
   }
 
   class TestCopierFactory implements CopierFactory {

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 import com.hotels.bdp.circustrain.core.replica.Replica;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImplTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -27,8 +25,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -47,6 +43,7 @@ import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
 import com.hotels.bdp.circustrain.api.conf.SourceTable;
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.core.replica.Replica;
@@ -121,7 +118,7 @@ public class ReplicationFactoryImplTest {
 
   @Test
   public void unpartitionedTableReplicationPartitionKeysEmpty() throws Exception {
-    when(table.getPartitionKeys()).thenReturn(Collections.<FieldSchema> emptyList());
+    when(table.getPartitionKeys()).thenReturn(Collections.<FieldSchema>emptyList());
     Replication replication = factory.newInstance(tableReplication);
     assertThat(replication, is(instanceOf(UnpartitionedTableReplication.class)));
   }
@@ -190,33 +187,6 @@ public class ReplicationFactoryImplTest {
   public void replicaDatabaseDoesNotExist() {
     when(replica.getDatabase(DATABASE)).thenThrow(new CircusTrainException(""));
     factory.newInstance(tableReplication);
-  }
-
-  @Test
-  public void mergeNullOptions() {
-    when(copierOptions.getCopierOptions()).thenReturn(null);
-    ReplicationFactoryImpl factory = new ReplicationFactoryImpl(sourceFactory, replicaFactory, copierFactoryManager,
-        copierListener, partitionPredicateFactory, copierOptions);
-    Map<String, Object> mergedCopierOptions = factory.mergeCopierOptions(null);
-    assertThat(mergedCopierOptions, is(not(nullValue())));
-    assertThat(mergedCopierOptions.isEmpty(), is(true));
-  }
-
-  @Test
-  public void mergeOptions() {
-    Map<String, Object> globalOptions = new HashMap<>();
-    globalOptions.put("one", Integer.valueOf(1));
-    globalOptions.put("two", Integer.valueOf(2));
-    when(copierOptions.getCopierOptions()).thenReturn(globalOptions);
-    Map<String, Object> overrideOptions = new HashMap<>();
-    overrideOptions.put("two", "two");
-    overrideOptions.put("three", "three");
-    ReplicationFactoryImpl factory = new ReplicationFactoryImpl(sourceFactory, replicaFactory, copierFactoryManager,
-        copierListener, partitionPredicateFactory, copierOptions);
-    Map<String, Object> mergedCopierOptions = factory.mergeCopierOptions(overrideOptions);
-    assertThat((Integer) mergedCopierOptions.get("one"), is(Integer.valueOf(1)));
-    assertThat((String) mergedCopierOptions.get("two"), is("two"));
-    assertThat((String) mergedCopierOptions.get("three"), is("three"));
   }
 
   @Test(expected = CircusTrainException.class)

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
+import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.event.CopierListener;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 import com.hotels.bdp.circustrain.core.replica.Replica;
@@ -151,8 +152,8 @@ public class UnpartitionedTableReplicationTest {
 
   @Test
   public void copierListenerCalledWhenException() throws Exception {
-    when(replica.getLocationManager(TableType.UNPARTITIONED, targetTableLoation, EVENT_ID, sourceLocationManager)).
-        thenReturn(replicaLocationManager);
+    when(replica.getLocationManager(TableType.UNPARTITIONED, targetTableLoation, EVENT_ID, sourceLocationManager))
+        .thenReturn(replicaLocationManager);
 
     when(copier.copy()).thenThrow(new CircusTrainException("copy failed"));
 

--- a/circus-train-distcp-copier/pom.xml
+++ b/circus-train-distcp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-distcp-copier</artifactId>

--- a/circus-train-gcp/pom.xml
+++ b/circus-train-gcp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-gcp</artifactId>

--- a/circus-train-hive-view/pom.xml
+++ b/circus-train-hive-view/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive-view</artifactId>

--- a/circus-train-hive/pom.xml
+++ b/circus-train-hive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive</artifactId>

--- a/circus-train-housekeeping/pom.xml
+++ b/circus-train-housekeeping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-housekeeping</artifactId>

--- a/circus-train-integration-tests/pom.xml
+++ b/circus-train-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-integration-tests</artifactId>

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-avro-schema.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-avro-schema.yml
@@ -1,0 +1,10 @@
+table-replications:
+  - source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_u
+    replica-table:
+      table-name: ct_table_u_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks
+      

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-avro-schema.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-avro-schema.yml
@@ -7,4 +7,4 @@ table-replications:
       table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
 security:
   credential-provider: jceks://file/${config-location}/aws.jceks
-      
+

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-avro-schema.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-avro-schema.yml
@@ -1,0 +1,9 @@
+table-replications:
+  - source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_u
+    replica-table:
+      table-name: ct_table_u_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,8 @@ import com.hotels.beeju.ThriftHiveMetaStoreJUnitRule;
 import com.hotels.housekeeping.model.LegacyReplicaPath;
 
 public class CircusTrainHdfsHdfsIntegrationTest {
+
+  private static final String AVRO_SCHEMA_CONTENT = "avro-schema content";
 
   private static final Logger LOG = LoggerFactory.getLogger(CircusTrainHdfsHdfsIntegrationTest.class);
 
@@ -258,18 +260,18 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     exit.expectSystemExitWithStatus(0);
     File config = dataFolder.getFile("partitioned-single-table-no-housekeeping-with-table-parameters.yml");
     CircusTrainRunner runner = CircusTrainRunner
-      .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
-      .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
-        sourceCatalog.driverClassName())
-      .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
-      .build();
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
     exit.checkAssertionAfterwards(new Assertion() {
       @Override
       public void checkAssertion() throws Exception {
         String jdbcUrl = housekeepingDbJdbcUrl();
         try (Connection conn = getConnection(jdbcUrl, HOUSEKEEPING_DB_USER, HOUSEKEEPING_DB_PASSWD)) {
           List<LegacyReplicaPath> cleanUpPaths = TestUtils
-            .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
+              .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
           assertThat(cleanUpPaths.size(), is(0));
         }
         Map<String, String> parameters = replicaCatalog.client().getTable(DATABASE, PARTITIONED_TABLE).getParameters();
@@ -288,18 +290,18 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     exit.expectSystemExitWithStatus(0);
     File config = dataFolder.getFile("partitioned-single-table-no-housekeeping-with-default-table-parameters.yml");
     CircusTrainRunner runner = CircusTrainRunner
-      .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
-      .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
-        sourceCatalog.driverClassName())
-      .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
-      .build();
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
     exit.checkAssertionAfterwards(new Assertion() {
       @Override
       public void checkAssertion() throws Exception {
         String jdbcUrl = housekeepingDbJdbcUrl();
         try (Connection conn = getConnection(jdbcUrl, HOUSEKEEPING_DB_USER, HOUSEKEEPING_DB_PASSWD)) {
           List<LegacyReplicaPath> cleanUpPaths = TestUtils
-            .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
+              .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
           assertThat(cleanUpPaths.size(), is(0));
         }
         Map<String, String> parameters = replicaCatalog.client().getTable(DATABASE, PARTITIONED_TABLE).getParameters();
@@ -326,18 +328,18 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     exit.expectSystemExitWithStatus(0);
     File config = dataFolder.getFile("partitioned-single-table-no-housekeeping.yml");
     CircusTrainRunner runner = CircusTrainRunner
-      .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
-      .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
-        sourceCatalog.driverClassName())
-      .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
-      .build();
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
     exit.checkAssertionAfterwards(new Assertion() {
       @Override
       public void checkAssertion() throws Exception {
         String jdbcUrl = housekeepingDbJdbcUrl();
         try (Connection conn = getConnection(jdbcUrl, HOUSEKEEPING_DB_USER, HOUSEKEEPING_DB_PASSWD)) {
           List<LegacyReplicaPath> cleanUpPaths = TestUtils
-            .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
+              .getCleanUpPaths(conn, "SELECT * FROM circus_train.legacy_replica_path");
           assertThat(cleanUpPaths.size(), is(0));
         }
         Map<String, String> parameters = replicaCatalog.client().getTable(DATABASE, PARTITIONED_TABLE).getParameters();
@@ -547,9 +549,7 @@ public class CircusTrainHdfsHdfsIntegrationTest {
       @Override
       public void checkAssertion() throws Exception {
         assertThat(replicaCatalog.client().tableExists(DATABASE, PARTITIONED_TABLE), is(true));
-        List<Partition> partitions = replicaCatalog
-            .client()
-            .listPartitions(DATABASE, PARTITIONED_TABLE, (short) 10);
+        List<Partition> partitions = replicaCatalog.client().listPartitions(DATABASE, PARTITIONED_TABLE, (short) 10);
 
         assertThat(partitions.size(), is(2));
         // Assert deleted path
@@ -594,9 +594,7 @@ public class CircusTrainHdfsHdfsIntegrationTest {
       @Override
       public void checkAssertion() throws Exception {
         assertThat(replicaCatalog.client().tableExists(DATABASE, PARTITIONED_TABLE), is(true));
-        List<Partition> partitions = replicaCatalog
-            .client()
-            .listPartitions(DATABASE, PARTITIONED_TABLE, (short) 10);
+        List<Partition> partitions = replicaCatalog.client().listPartitions(DATABASE, PARTITIONED_TABLE, (short) 10);
 
         assertThat(partitions.size(), is(1));
         // Assert deleted path
@@ -987,12 +985,11 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
 
     java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaPath);
-
-    String avroSchemaBaseUrl = sourceAvroSchemaPath.toString();
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
-    sourceTable.putToParameters("avro.schema.url", avroSchemaBaseUrl);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
     sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
 
     exit.expectSystemExitWithStatus(0);
@@ -1011,6 +1008,11 @@ public class CircusTrainHdfsHdfsIntegrationTest {
         String expectedReplicaSchemaUrl = replicaWarehouseUri.toURI().toString() + "ct_database/";
         String transformedAvroUrl = replicaHiveTable.getParameters().get("avro.schema.url");
         assertThat(transformedAvroUrl, startsWith(expectedReplicaSchemaUrl));
+        Path copiedSchema = new Path(transformedAvroUrl);
+        FileSystem fs = FileSystem.get(replicaCatalog.conf());
+        assertTrue(fs.exists(copiedSchema));
+        String content = new String(Files.readAllBytes(java.nio.file.Paths.get(copiedSchema.toUri())));
+        assertThat(content, is(AVRO_SCHEMA_CONTENT));
       }
     });
 
@@ -1023,8 +1025,7 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
 
     java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaPath);
-
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
     String avroSchemaBaseUrl = sourceAvroSchemaPath.toString();
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
@@ -1059,9 +1060,9 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
 
     String avroParameter = "avro.schema.url";
-    java.nio.file.Path sourceAvroSchemaUploadPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaUploadPath);
-    String avroSchemaBaseUrl = sourceAvroSchemaUploadPath.toString();
+    java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
 
     URI replicaLocation = toUri(replicaWarehouseUri, DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
     TestUtils
@@ -1072,7 +1073,7 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     replicaCatalog.client().alter_table(table.getDbName(), table.getTableName(), table);
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
-    sourceTable.putToParameters(avroParameter, avroSchemaBaseUrl);
+    sourceTable.putToParameters(avroParameter, avroSchemaUrl);
     sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
 
     exit.expectSystemExitWithStatus(0);
@@ -1100,9 +1101,9 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     helper.createManagedPartitionedTable(toUri(sourceWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
 
-    java.nio.file.Path sourceAvroSchemaUploadPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaUploadPath);
-    String avroSchemaBaseUrl = sourceAvroSchemaUploadPath.toString();
+    java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
 
     URI replicaLocation = toUri(replicaWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
     TestUtils
@@ -1118,13 +1119,13 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     replicaCatalog.client().alter_table(table.getDbName(), table.getTableName(), table);
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
-    sourceTable.putToParameters("avro.schema.url", avroSchemaBaseUrl);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
 
     sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
     Partition partition = sourceCatalog
         .client()
         .getPartition(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE, "continent=Asia/country=China");
-    partition.putToParameters("avro.schema.url", avroSchemaBaseUrl);
+    partition.putToParameters("avro.schema.url", avroSchemaUrl);
 
     sourceCatalog.client().alter_partition(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE, partition);
 
@@ -1160,12 +1161,11 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
 
     java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaPath);
-
-    String avroSchemaBaseUrl = sourceAvroSchemaPath.toString();
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
-    sourceTable.putToParameters("avro.schema.url", avroSchemaBaseUrl);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
     sourceTable.putToParameters("circus.train.test.transformation", "enabled");
     sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
 
@@ -1201,23 +1201,22 @@ public class CircusTrainHdfsHdfsIntegrationTest {
     LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
 
     java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
-    Files.createDirectories(sourceAvroSchemaPath);
-
-    String avroSchemaBaseUrl = sourceAvroSchemaPath.toString();
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
 
     Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
-    sourceTable.putToParameters("avro.schema.url", avroSchemaBaseUrl);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
     sourceTable.putToParameters("circus.train.test.transformation", "enabled");
     sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
 
     exit.expectSystemExitWithStatus(0);
     File config = dataFolder.getFile("unpartitioned-single-table-multiple-transformation-overrides.yml");
     CircusTrainRunner runner = CircusTrainRunner
-      .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
-      .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
-        sourceCatalog.driverClassName())
-      .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
-      .build();
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
 
     exit.checkAssertionAfterwards(new Assertion() {
       @Override

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,12 @@ import static com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3URIs.toAmazonS3U
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.gaul.s3proxy.junit.S3ProxyRule;
@@ -73,6 +76,7 @@ public class CircusTrainHdfsS3IntegrationTest {
   private static final String TARGET_PARTITIONED_TABLE = "ct_table_p_copy";
 
   private static final String DUMMY_EVENT_ID = "dummyEventID";
+  private static final String AVRO_SCHEMA_CONTENT = "avro schema content";
 
   public @Rule ExpectedSystemExit exit = ExpectedSystemExit.none();
   public @Rule TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -85,7 +89,7 @@ public class CircusTrainHdfsS3IntegrationTest {
       .ignoreUnknownHeaders()
       .build();
   private final Map<String, String> metastoreProperties = ImmutableMap
-      .<String, String> builder()
+      .<String, String>builder()
       .put(ENDPOINT, String.format("http://127.0.0.1:%d", s3ProxyPort))
       .put(ACCESS_KEY, S3_ACCESS_KEY)
       .put(SECRET_KEY, S3_SECRET_KEY)
@@ -126,7 +130,7 @@ public class CircusTrainHdfsS3IntegrationTest {
   private AmazonS3 newS3Client(String tableUri) {
     AmazonS3URI base = toAmazonS3URI(URI.create(tableUri));
     S3S3CopierOptions s3s3CopierOptions = new S3S3CopierOptions(ImmutableMap
-        .<String, Object> builder()
+        .<String, Object>builder()
         .put(S3S3CopierOptions.Keys.S3_ENDPOINT_URI.keyName(), s3Proxy.getUri().toString())
         .build());
     return s3ClientFactory.newInstance(base, s3s3CopierOptions);
@@ -159,14 +163,71 @@ public class CircusTrainHdfsS3IntegrationTest {
         assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
         // Assert copied files
         File dataFile = new File(sourceTableUri.getPath(), PART_00000);
-        String fileKeyRegex = String.format("%s/%s/ctt-\\d{8}t\\d{6}.\\d{3}z-\\w{8}/%s", DATABASE,
-            TARGET_UNPARTITIONED_TABLE, PART_00000);
+        String fileKeyRegex = String
+            .format("%s/%s/ctt-\\d{8}t\\d{6}.\\d{3}z-\\w{8}/%s", DATABASE, TARGET_UNPARTITIONED_TABLE, PART_00000);
         List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
         assertThat(replicaFiles.size(), is(1));
         for (S3ObjectSummary objectSummary : replicaFiles) {
           assertThat(objectSummary.getSize(), is(dataFile.length()));
           assertThat(objectSummary.getKey().matches(fileKeyRegex), is(true));
         }
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void unpartitionedTableWithExternalAvroSchema() throws Exception {
+    final URI sourceTableUri = toUri(sourceWarehouseUri, DATABASE, UNPARTITIONED_TABLE);
+    helper.createUnpartitionedTable(sourceTableUri);
+
+    java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
+
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, UNPARTITIONED_TABLE);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("unpartitioned-single-table-avro-schema.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3MapReduceCpOptionsParser.S3_ENDPOINT_URI, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        // Assert location
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+        String eventId = hiveTable.getParameters().get(REPLICATION_EVENT.parameterName());
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_UNPARTITIONED_TABLE + "/" + eventId);
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        // Assert copied files
+        File dataFile = new File(sourceTableUri.getPath(), PART_00000);
+        String fileKeyRegex = String
+            .format("%s/%s/ctt-\\d{8}t\\d{6}.\\d{3}z-\\w{8}/%s", DATABASE, TARGET_UNPARTITIONED_TABLE, PART_00000);
+        List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
+        assertThat(replicaFiles.size(), is(2));
+        // assert Avro schema copied
+        S3ObjectSummary s3ObjectSummary = replicaFiles.get(0);
+        String content = IOUtils
+            .toString(s3Client
+                .getObject(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey())
+                .getObjectContent()
+                .getDelegateStream());
+        assertThat(content, is(AVRO_SCHEMA_CONTENT));
+        String transformedAvroUrl = hiveTable.getParameters().get("avro.schema.url");
+        assertThat(transformedAvroUrl, is(replicaLocation + "/.schema/avro-schema-file.test"));
+        // data file
+        assertThat(replicaFiles.get(1).getSize(), is(dataFile.length()));
+        assertThat(replicaFiles.get(1).getKey().matches(fileKeyRegex), is(true));
       }
     });
     runner.run(config.getAbsolutePath());
@@ -199,8 +260,9 @@ public class CircusTrainHdfsS3IntegrationTest {
         assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
         assertThat(eventId, startsWith("ctp-"));
         // Assert partitions
-        List<Partition> partitions = replicaCatalog.client().listPartitions(DATABASE, TARGET_PARTITIONED_TABLE,
-            (short) -1);
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_TABLE, (short) -1);
         assertThat(partitions.size(), is(0));
         // Assert table directory
         List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
@@ -213,8 +275,8 @@ public class CircusTrainHdfsS3IntegrationTest {
   @Test
   public void partitionedTableWithNoPartitionsMetadataUpdate() throws Exception {
     URI sourceTableUri = toUri(sourceWarehouseUri, DATABASE, PARTITIONED_TABLE);
-    Table sourceTable = TestUtils.createPartitionedTable(sourceCatalog.client(), DATABASE, PARTITIONED_TABLE,
-        sourceTableUri);
+    Table sourceTable = TestUtils
+        .createPartitionedTable(sourceCatalog.client(), DATABASE, PARTITIONED_TABLE, sourceTableUri);
 
     // creating replicaTable
     final URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_PARTITIONED_TABLE);
@@ -251,8 +313,9 @@ public class CircusTrainHdfsS3IntegrationTest {
         assertThat(isExternalTable(hiveTable), is(true));
         assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
         // Assert partitions
-        List<Partition> partitions = replicaCatalog.client().listPartitions(DATABASE, TARGET_PARTITIONED_TABLE,
-            (short) -1);
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_TABLE, (short) -1);
         assertThat(partitions.size(), is(0));
         // Assert table directory
         List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,13 @@ import static com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3URIs.toAmazonS3U
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.gaul.s3proxy.junit.S3ProxyRule;
@@ -71,6 +74,8 @@ public class CircusTrainS3S3IntegrationTest {
   private static final String TARGET_UNPARTITIONED_TABLE = "ct_table_u_copy";
   private static final String TARGET_PARTITIONED_TABLE = "ct_table_p_copy";
 
+  private static final String AVRO_SCHEMA_CONTENT = "avro schema content";
+
   public @Rule ExpectedSystemExit exit = ExpectedSystemExit.none();
   public @Rule TemporaryFolder temporaryFolder = new TemporaryFolder();
   public @Rule DataFolder dataFolder = new ClassDataFolder();
@@ -82,7 +87,7 @@ public class CircusTrainS3S3IntegrationTest {
       .ignoreUnknownHeaders()
       .build();
   private final Map<String, String> metastoreProperties = ImmutableMap
-      .<String, String> builder()
+      .<String, String>builder()
       .put(ENDPOINT, String.format("http://127.0.0.1:%d", s3ProxyPort))
       .put(ACCESS_KEY, S3_ACCESS_KEY)
       .put(SECRET_KEY, S3_SECRET_KEY)
@@ -120,7 +125,7 @@ public class CircusTrainS3S3IntegrationTest {
   private AmazonS3 newS3Client(String tableUri) {
     AmazonS3URI base = toAmazonS3URI(URI.create(tableUri));
     S3S3CopierOptions s3s3CopierOptions = new S3S3CopierOptions(ImmutableMap
-        .<String, Object> builder()
+        .<String, Object>builder()
         .put(S3S3CopierOptions.Keys.S3_ENDPOINT_URI.keyName(), s3Proxy.getUri().toString())
         .build());
     return s3ClientFactory.newInstance(base, s3s3CopierOptions);
@@ -128,8 +133,9 @@ public class CircusTrainS3S3IntegrationTest {
 
   @Test
   public void unpartitionedTable() throws Exception {
-    TestUtils.createUnpartitionedTable(sourceCatalog.client(), DATABASE, UNPARTITIONED_TABLE,
-        toUri("s3a://source/", DATABASE, UNPARTITIONED_TABLE));
+    TestUtils
+        .createUnpartitionedTable(sourceCatalog.client(), DATABASE, UNPARTITIONED_TABLE,
+            toUri("s3a://source/", DATABASE, UNPARTITIONED_TABLE));
 
     final File dataFile = temporaryFolder.newFile();
     FileUtils.writeStringToFile(dataFile, "1\trob\tbristol\n2\tsam\ttoronto\n");
@@ -169,6 +175,69 @@ public class CircusTrainS3S3IntegrationTest {
   }
 
   @Test
+  public void unpartitionedTableWithExternalAvroSchema() throws Exception {
+    TestUtils
+        .createUnpartitionedTable(sourceCatalog.client(), DATABASE, UNPARTITIONED_TABLE,
+            toUri("s3a://source/", DATABASE, UNPARTITIONED_TABLE));
+
+    final File dataFile = temporaryFolder.newFile();
+    FileUtils.writeStringToFile(dataFile, "1\trob\tbristol\n2\tsam\ttoronto\n");
+    String fileKey = String.format("%s/%s/%s", DATABASE, UNPARTITIONED_TABLE, PART_00000);
+    s3Client.putObject("source", fileKey, dataFile);
+
+    java.nio.file.Path sourceAvroSchemaPath = Paths.get(sourceWarehouseUri.toString() + "/avro-schema-file.test");
+    Files.write(sourceAvroSchemaPath, AVRO_SCHEMA_CONTENT.getBytes());
+    String avroSchemaUrl = sourceAvroSchemaPath.toString();
+
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, UNPARTITIONED_TABLE);
+    sourceTable.putToParameters("avro.schema.url", avroSchemaUrl);
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("unpartitioned-single-table-avro-schema.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3S3CopierOptions.Keys.S3_ENDPOINT_URI.keyName(), s3Proxy.getUri().toString())
+        .sourceConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        // Assert location
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+        String eventId = hiveTable.getParameters().get(REPLICATION_EVENT.parameterName());
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_UNPARTITIONED_TABLE + "/" + eventId);
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        // Assert copied files
+        List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
+        assertThat(replicaFiles.size(), is(2));
+
+        // assert Avro schema copied
+        S3ObjectSummary s3ObjectSummary = replicaFiles.get(0);
+        String content = IOUtils
+            .toString(s3Client
+                .getObject(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey())
+                .getObjectContent()
+                .getDelegateStream());
+        assertThat(content, is(AVRO_SCHEMA_CONTENT));
+        String transformedAvroUrl = hiveTable.getParameters().get("avro.schema.url");
+        assertThat(transformedAvroUrl, is(replicaLocation + "/.schema/avro-schema-file.test"));
+        // data file
+        assertThat(replicaFiles.get(1).getSize(), is(dataFile.length()));
+        String fileKey = String.format("%s/%s/%s/%s", DATABASE, TARGET_UNPARTITIONED_TABLE, eventId, PART_00000);
+        assertThat(replicaFiles.get(1).getKey(), is(fileKey));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  @Test
   public void partitionedTableWithNoPartitionsMirror() throws Exception {
     final URI sourceTableLocation = toUri("s3a://source/", DATABASE, PARTITIONED_TABLE);
     TestUtils.createPartitionedTable(sourceCatalog.client(), DATABASE, PARTITIONED_TABLE, sourceTableLocation);
@@ -195,8 +264,9 @@ public class CircusTrainS3S3IntegrationTest {
         assertThat(hiveTable.getParameters().get(REPLICATION_EVENT.parameterName()), startsWith("ctp-"));
         assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
         // Assert partitions
-        List<Partition> partitions = replicaCatalog.client().listPartitions(DATABASE, TARGET_PARTITIONED_TABLE,
-            (short) -1);
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_TABLE, (short) -1);
         assertThat(partitions.size(), is(0));
       }
     });

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/utils/TestUtils.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/utils/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,9 +204,9 @@ public final class TestUtils {
       List<FieldSchema> partitionColumns) {
     List<String> dataColumnNames = toQualifiedColumnNames(table, dataColumns);
     List<String> partitionColumnNames = partitionColumns != null ? toQualifiedColumnNames(table, partitionColumns)
-        : ImmutableList.<String> of();
+        : ImmutableList.<String>of();
     List<String> colNames = ImmutableList
-        .<String> builder()
+        .<String>builder()
         .addAll(dataColumnNames)
         .addAll(partitionColumnNames)
         .build();

--- a/circus-train-metrics/pom.xml
+++ b/circus-train-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-metrics</artifactId>

--- a/circus-train-package/pom.xml
+++ b/circus-train-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/pom.xml
+++ b/circus-train-s3-mapreduce-cp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp-copier</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopier.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierOptions;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 import com.hotels.bdp.circustrain.metrics.JobCounterGauge;
 import com.hotels.bdp.circustrain.metrics.JobMetrics;
@@ -101,7 +102,7 @@ public class S3MapReduceCpCopier implements Copier {
       defaultCredentialsProvider = URI.create(defaultCredentialsProviderString);
     }
 
-    URI replicaDataLocationUri = toDirectoryUri(replicaDataLocation);
+    URI replicaDataLocationUri = toURI(replicaDataLocation);
     S3MapReduceCpOptionsParser optionsParser = null;
     if (sourceDataLocations.isEmpty()) {
       LOG.debug("Will copy all sub-paths.");
@@ -114,6 +115,14 @@ public class S3MapReduceCpCopier implements Copier {
           defaultCredentialsProvider);
     }
     return optionsParser.parse(copierOptions);
+  }
+
+  private URI toURI(Path replicaDataLocation) {
+    if (Boolean.parseBoolean((String) copierOptions.get(CopierOptions.COPY_DESTINATION_IS_FILE))) {
+      return replicaDataLocation.toUri();
+    } else {
+      return toDirectoryUri(replicaDataLocation);
+    }
   }
 
   private URI toDirectoryUri(Path path) {

--- a/circus-train-s3-mapreduce-cp/pom.xml
+++ b/circus-train-s3-mapreduce-cp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp</artifactId>

--- a/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptions.java
+++ b/circus-train-s3-mapreduce-cp/src/main/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -420,7 +420,9 @@ public class S3MapReduceCpOptions {
     this.cannedAcl = cannedAcl;
   }
 
-  public String getAssumeRole() { return assumeRole; }
+  public String getAssumeRole() {
+    return assumeRole;
+  }
 
   public void setAssumeRole(String assumeRole) {
     this.assumeRole = assumeRole;
@@ -461,29 +463,56 @@ public class S3MapReduceCpOptions {
 
   @Override
   public String toString() {
-    return "S3MapReduceCpOptions{" +
-        "help=" + help +
-        ", async=" + async +
-        ", sources=" + sources +
-        ", target=" + target +
-        ", credentialsProvider=" + credentialsProvider +
-        ", multipartUploadPartSize=" + multipartUploadPartSize +
-        ", s3ServerSideEncryption=" + s3ServerSideEncryption +
-        ", storageClass='" + storageClass + '\'' +
-        ", maxBandwidth=" + maxBandwidth +
-        ", numberOfUploadWorkers=" + numberOfUploadWorkers +
-        ", multipartUploadThreshold=" + multipartUploadThreshold +
-        ", maxMaps=" + maxMaps +
-        ", copyStrategy='" + copyStrategy + '\'' +
-        ", logPath=" + logPath +
-        ", region='" + region + '\'' +
-        ", ignoreFailures=" + ignoreFailures +
-        ", s3EndpointUri=" + s3EndpointUri +
-        ", uploadRetryCount=" + uploadRetryCount +
-        ", uploadRetryDelayMs=" + uploadRetryDelayMs +
-        ", uploadBufferSize=" + uploadBufferSize +
-        ", cannedAcl='" + cannedAcl + '\'' +
-        ", assumeRole='" + assumeRole + '\'' +
-        '}';
+    return "S3MapReduceCpOptions{"
+        + "help="
+        + help
+        + ", async="
+        + async
+        + ", sources="
+        + sources
+        + ", target="
+        + target
+        + ", credentialsProvider="
+        + credentialsProvider
+        + ", multipartUploadPartSize="
+        + multipartUploadPartSize
+        + ", s3ServerSideEncryption="
+        + s3ServerSideEncryption
+        + ", storageClass='"
+        + storageClass
+        + '\''
+        + ", maxBandwidth="
+        + maxBandwidth
+        + ", numberOfUploadWorkers="
+        + numberOfUploadWorkers
+        + ", multipartUploadThreshold="
+        + multipartUploadThreshold
+        + ", maxMaps="
+        + maxMaps
+        + ", copyStrategy='"
+        + copyStrategy
+        + '\''
+        + ", logPath="
+        + logPath
+        + ", region='"
+        + region
+        + '\''
+        + ", ignoreFailures="
+        + ignoreFailures
+        + ", s3EndpointUri="
+        + s3EndpointUri
+        + ", uploadRetryCount="
+        + uploadRetryCount
+        + ", uploadRetryDelayMs="
+        + uploadRetryDelayMs
+        + ", uploadBufferSize="
+        + uploadBufferSize
+        + ", cannedAcl='"
+        + cannedAcl
+        + '\''
+        + ", assumeRole='"
+        + assumeRole
+        + '\''
+        + '}';
   }
 }

--- a/circus-train-s3-s3-copier/pom.xml
+++ b/circus-train-s3-s3-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-s3-copier</artifactId>

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,7 @@ public class S3S3CopierTest {
     client.createBucket("source");
     client.createBucket("target");
 
-    when(s3ClientFactory.newInstance(any(AmazonS3URI.class), any(S3S3CopierOptions.class)))
-        .thenReturn(newClient());
+    when(s3ClientFactory.newInstance(any(AmazonS3URI.class), any(S3S3CopierOptions.class))).thenReturn(newClient());
   }
 
   private AmazonS3 newClient() {
@@ -130,6 +129,23 @@ public class S3S3CopierTest {
     assertThat(metrics.getBytesReplicated(), is(7L));
     assertThat(metrics.getMetrics().get(S3S3CopierMetrics.Metrics.TOTAL_BYTES_TO_REPLICATE.name()), is(7L));
     S3Object object = client.getObject("target", "data");
+    String data = IOUtils.toString(object.getObjectContent());
+    assertThat(data, is("bar foo"));
+    assertThat(registry.getGauges().containsKey(RunningMetrics.S3S3_CP_BYTES_REPLICATED.name()), is(true));
+  }
+
+  @Test
+  public void copyOneFile() throws Exception {
+    client.putObject("source", "data", inputData);
+
+    Path sourceBaseLocation = new Path("s3://source/data");
+    Path replicaLocation = new Path("s3://target/data2");
+    List<Path> sourceSubLocations = new ArrayList<>();
+    S3S3Copier s3s3Copier = newS3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation);
+    Metrics metrics = s3s3Copier.copy();
+    assertThat(metrics.getBytesReplicated(), is(7L));
+    assertThat(metrics.getMetrics().get(S3S3CopierMetrics.Metrics.TOTAL_BYTES_TO_REPLICATE.name()), is(7L));
+    S3Object object = client.getObject("target", "data2");
     String data = IOUtils.toString(object.getObjectContent());
     assertThat(data, is("bar foo"));
     assertThat(registry.getGauges().containsKey(RunningMetrics.S3S3_CP_BYTES_REPLICATED.name()), is(true));
@@ -234,8 +250,9 @@ public class S3S3CopierTest {
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
@@ -272,8 +289,9 @@ public class S3S3CopierTest {
     TransferManager mockedTransferManager = Mockito.mock(TransferManager.class);
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenThrow(new AmazonServiceException("MyCause"));
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenThrow(new AmazonServiceException("MyCause"));
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
         mockedTransferManagerFactory, listObjectsRequestFactory, registry, s3S3CopierOptions);
     try {
@@ -298,8 +316,9 @@ public class S3S3CopierTest {
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
     when(copy.getProgress()).thenReturn(new TransferProgress());
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     doThrow(new AmazonClientException("cause")).when(copy).waitForCompletion();
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
         mockedTransferManagerFactory, listObjectsRequestFactory, registry, s3S3CopierOptions);
@@ -326,8 +345,9 @@ public class S3S3CopierTest {
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
 
@@ -355,8 +375,9 @@ public class S3S3CopierTest {
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(customOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
 
@@ -377,17 +398,18 @@ public class S3S3CopierTest {
     Path replicaLocation = new Path("s3://target/");
     List<Path> sourceSubLocations = new ArrayList<>();
     Map<String, Object> copierOptions = new HashMap<>();
-    copierOptions.put(S3S3CopierOptions.Keys.CANNED_ACL.keyName(),
-        CannedAccessControlList.BucketOwnerFullControl.toString());
+    copierOptions
+        .put(S3S3CopierOptions.Keys.CANNED_ACL.keyName(), CannedAccessControlList.BucketOwnerFullControl.toString());
     S3S3CopierOptions customOptions = new S3S3CopierOptions(copierOptions);
 
     TransferManagerFactory mockedTransferManagerFactory = Mockito.mock(TransferManagerFactory.class);
     TransferManager mockedTransferManager = Mockito.mock(TransferManager.class);
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(customOptions)))
-            .thenReturn(mockedTransferManager);
+        .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-            any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
 
@@ -407,14 +429,14 @@ public class S3S3CopierTest {
     Path replicaLocation = new Path("s3://target/");
     List<Path> sourceSubLocations = new ArrayList<>();
 
-    TransferManagerFactory mockedTransferManagerFactory = Mockito.mock(
-        TransferManagerFactory.class);
+    TransferManagerFactory mockedTransferManagerFactory = Mockito.mock(TransferManagerFactory.class);
     TransferManager mockedTransferManager = Mockito.mock(TransferManager.class);
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenThrow(new AmazonClientException("S3 error"));
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenThrow(new AmazonClientException("S3 error"));
     TransferProgress transferProgress = new TransferProgress();
     when(copy.getProgress()).thenReturn(transferProgress);
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
@@ -439,25 +461,25 @@ public class S3S3CopierTest {
     Path replicaLocation = new Path("s3://target/foo/");
     List<Path> sourceSubLocations = new ArrayList<>();
 
-    TransferManagerFactory mockedTransferManagerFactory = Mockito.mock(
-        TransferManagerFactory.class);
+    TransferManagerFactory mockedTransferManagerFactory = Mockito.mock(TransferManagerFactory.class);
     TransferManager mockedTransferManager = Mockito.mock(TransferManager.class);
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(mockedTransferManager.copy(any(CopyObjectRequest.class), any(AmazonS3.class),
-        any(TransferStateChangeListener.class))).thenReturn(copy);
+    when(mockedTransferManager
+        .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
+            .thenReturn(copy);
     TransferProgress transferProgress = new TransferProgress();
     transferProgress.setTotalBytesToTransfer(7);
     when(copy.getProgress()).thenReturn(transferProgress);
-    doThrow(new AmazonClientException("cause"))
-        .doNothing().when(copy).waitForCompletion();
+    doThrow(new AmazonClientException("cause")).doNothing().when(copy).waitForCompletion();
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
         mockedTransferManagerFactory, listObjectsRequestFactory, registry, s3S3CopierOptions);
     try {
       Metrics metrics = s3s3Copier.copy();
       ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
-      verify(mockedTransferManager, Mockito.times(3)).copy(captor.capture(), any(AmazonS3.class), any(TransferStateChangeListener.class));
+      verify(mockedTransferManager, Mockito.times(3))
+          .copy(captor.capture(), any(AmazonS3.class), any(TransferStateChangeListener.class));
       List<CopyObjectRequest> capturedCopyRequests = captor.getAllValues();
       assertThat(capturedCopyRequests.get(0).getSourceKey(), is(sourceKey1));
       assertThat(capturedCopyRequests.get(1).getSourceKey(), is(sourceKey2));

--- a/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparison-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-filter-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-filter-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-filter-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-tool-core/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-core</artifactId>

--- a/circus-train-tool-parent/circus-train-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool</artifactId>

--- a/circus-train-tool-parent/pom.xml
+++ b/circus-train-tool-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>circus-train-parent</artifactId>
   <description>circus-train replicates data and hive metadata between various clusters</description>
-  <version>15.0.1-SNAPSHOT</version>
+  <version>15.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Circus Train Parent</name>
   <inceptionYear>2016</inceptionYear>


### PR DESCRIPTION

The idea is to reuse the Copier for the avro schema. Treating it as a data file benefit is that any fixes we do in the copier (regarding ACL, credentials or anything) will be picked up automatically. The only downside I can think of is custom copiers not expecting to copy a schema file. But perhaps that's something we can live with or can be adjusted fairly easily in custom third party copiers.


fixes #162 