### PR TITLE
Issue #166 - Replica.updateMetastore calls metastore with batched partition lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [15.1.1] - TBD
+### Fixed
+* When replicating tables with large numbers of partitions, `Replica.updateMetadata` now calls add/alter partition in batches of 1000. See [#166](https://github.com/HotelsDotCom/circus-train/issues/166). 
+
 ## [15.1.0] - 2020-01-28
 ### Changed
 * AVRO Schema Copier now re-uses the normal 'data' copier instead of its own. See [#162](https://github.com/HotelsDotCom/circus-train/issues/162). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [15.1.1] - TBD
+## [15.1.1] - 2020-02-06
 ### Fixed
 * When replicating tables with large numbers of partitions, `Replica.updateMetadata` now calls add/alter partition in batches of 1000. See [#166](https://github.com/HotelsDotCom/circus-train/issues/166). 
 

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/replica/Replica.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/replica/Replica.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -44,9 +42,11 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -30,21 +30,15 @@ import static org.mockito.Mockito.when;
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
 
-import com.google.common.base.Supplier;
-import com.google.common.collect.Lists;
-import com.hotels.bdp.circustrain.api.CircusTrainException;
-import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
-import com.hotels.bdp.circustrain.api.conf.ReplicaCatalog;
-import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
-import com.hotels.bdp.circustrain.api.conf.TableReplication;
-import com.hotels.bdp.circustrain.api.event.ReplicaCatalogListener;
-import com.hotels.bdp.circustrain.api.listener.HousekeepingListener;
-import com.hotels.bdp.circustrain.api.metadata.ColumnStatisticsTransformation;
-import com.hotels.bdp.circustrain.api.metadata.PartitionTransformation;
-import com.hotels.bdp.circustrain.api.metadata.TableTransformation;
-import com.hotels.bdp.circustrain.core.PartitionsAndStatistics;
-import com.hotels.bdp.circustrain.core.TableAndStatistics;
-import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.collections.ListUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -75,14 +69,22 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
+
+import com.hotels.bdp.circustrain.api.CircusTrainException;
+import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
+import com.hotels.bdp.circustrain.api.conf.ReplicaCatalog;
+import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
+import com.hotels.bdp.circustrain.api.event.ReplicaCatalogListener;
+import com.hotels.bdp.circustrain.api.listener.HousekeepingListener;
+import com.hotels.bdp.circustrain.api.metadata.ColumnStatisticsTransformation;
+import com.hotels.bdp.circustrain.api.metadata.PartitionTransformation;
+import com.hotels.bdp.circustrain.api.metadata.TableTransformation;
+import com.hotels.bdp.circustrain.core.PartitionsAndStatistics;
+import com.hotels.bdp.circustrain.core.TableAndStatistics;
+import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReplicaTest {

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -21,14 +21,30 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
-import static org.mockito.Mockito.*;
 
-import java.io.IOException;
-import java.util.*;
-
+import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
+import com.hotels.bdp.circustrain.api.CircusTrainException;
+import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
+import com.hotels.bdp.circustrain.api.conf.ReplicaCatalog;
+import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
+import com.hotels.bdp.circustrain.api.event.ReplicaCatalogListener;
+import com.hotels.bdp.circustrain.api.listener.HousekeepingListener;
+import com.hotels.bdp.circustrain.api.metadata.ColumnStatisticsTransformation;
+import com.hotels.bdp.circustrain.api.metadata.PartitionTransformation;
+import com.hotels.bdp.circustrain.api.metadata.TableTransformation;
+import com.hotels.bdp.circustrain.core.PartitionsAndStatistics;
+import com.hotels.bdp.circustrain.core.TableAndStatistics;
+import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -58,22 +74,14 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.base.Supplier;
-import com.google.common.collect.Lists;
-
-import com.hotels.bdp.circustrain.api.CircusTrainException;
-import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
-import com.hotels.bdp.circustrain.api.conf.ReplicaCatalog;
-import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
-import com.hotels.bdp.circustrain.api.conf.TableReplication;
-import com.hotels.bdp.circustrain.api.event.ReplicaCatalogListener;
-import com.hotels.bdp.circustrain.api.listener.HousekeepingListener;
-import com.hotels.bdp.circustrain.api.metadata.ColumnStatisticsTransformation;
-import com.hotels.bdp.circustrain.api.metadata.PartitionTransformation;
-import com.hotels.bdp.circustrain.api.metadata.TableTransformation;
-import com.hotels.bdp.circustrain.core.PartitionsAndStatistics;
-import com.hotels.bdp.circustrain.core.TableAndStatistics;
-import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReplicaTest {


### PR DESCRIPTION
Fixes Issue #166 

Log file output from running test on table with 5019 partitions:
```
21:01:53.209 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Updating replica table metadata.
21:01:53.334 [main] INFO  com.hotels.hcommon.hive.metastore.client.closeable.CloseableMetaStoreClientInvocationHandler - Couldn't invoke method public abstract org.apache.hadoop.hive.metastore.api.Table org.apache.hadoop.hive.metastore.IMetaStoreClient.getTable(java.lang.String,java.lang.String) throws org.apache.hadoop.hive.metastore.api.MetaException,org.apache.thrift.TException,org.apache.hadoop.hive.metastore.api.NoSuchObjectException
21:11:02.672 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating 5019 new partitions.
21:11:02.677 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 0 through 999
21:15:21.485 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 1000 through 1999
21:19:35.692 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 2000 through 2999
21:23:57.927 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 3000 through 3999
21:28:13.187 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 4000 through 4999
21:32:30.142 [main] INFO  com.hotels.bdp.circustrain.core.replica.Replica - Creating partitions 5000 through 5018
21:32:35.818 [main] INFO  hive.metastore - Closed a connection to metastore, current connections: 0
21:32:35.818 [main] INFO  com.hotels.bdp.circustrain.core.PartitionedTableReplication - Replicated 5019 partitions of table test.barnparttest5000.
```