### PR TITLE
Disable coveralls for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,22 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Init Coveralls
+      shell: bash
+      run: |
+          COVERALLS_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}
+          if [[ -z "${COVERALLS_TOKEN}" ]];
+          then
+             echo "Coveralls token not available"
+             COVERALLS_SKIP=true
+          else
+             echo "Coveralls token available"
+             COVERALLS_SKIP=false
+          fi
+          echo ::set-env name=COVERALLS_SKIP::${COVERALLS_SKIP}
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: 8
     - name: Run Maven Targets
-      run: echo Hello World 2
+      run:  echo "mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run: echo Hello World
+      run: echo Hello World 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run:  echo "mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}"
+      run:  mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run:  mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run: mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: echo Hello World


### PR DESCRIPTION
This change only runs Coveralls for pull requests on non-forked branches. This is because secrets (like the Coveralls repo token) aren't allowed to be shared outside of the org (makes sense) but this was previously failing the build right at the end when trying to send the report to Coveralls as the token for that was missing. So instead what we do is disable the Coveralls report if the secret is missing. I've tested this from a fork and non-fork and it seems to work correctly.