### PR TITLE
Full overwrite replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ nbactions.xml
 # Maven 
 target/
 dependency-reduced-pom.xml
+*.versionsBackup
 
 # Any left over .svn folders
 .svn/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Changed
 * Changed version of `hive.version` to `2.3.7` (was `2.3.2`). This allows Circus Train to be used on JDK>=9.
 
+### Added
+* Replication mode `FULL_OVERWRITE` to overwrite a previously replicated table. Useful for incompatible schema changes. 
+
 ## [16.1.0] - 2020-03-18
 ### Changed
 * Updated S3S3Copier to have a configurable max number of threads to pass to TransferManager.

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/conf/ReplicationMode.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/conf/ReplicationMode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ public enum ReplicationMode {
 
   FULL,
   METADATA_MIRROR,
-  METADATA_UPDATE;
+  METADATA_UPDATE,
+  FULL_OVERWRITE;
+
 
 }

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -107,6 +107,8 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
       replication = new PartitionedTableMetadataMirrorReplication(sourceDatabaseName, sourceTableName,
           partitionPredicate, source, replica, eventIdFactory, replicaDatabaseName, replicaTableName);
       break;
+
+    case FULL_OVERWRITE:
     case FULL:
       Map<String, Object> mergedCopierOptions = tableReplication
           .getMergedCopierOptions(copierOptions.getCopierOptions());
@@ -141,6 +143,7 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
       replication = new UnpartitionedTableMetadataMirrorReplication(sourceDatabaseName, sourceTableName, source,
           replica, eventIdFactory, replicaDatabaseName, replicaTableName);
       break;
+    case FULL_OVERWRITE:
     case FULL:
       Map<String, Object> mergedCopierOptions = tableReplication
           .getMergedCopierOptions(copierOptions.getCopierOptions());

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -107,7 +107,6 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
       replication = new PartitionedTableMetadataMirrorReplication(sourceDatabaseName, sourceTableName,
           partitionPredicate, source, replica, eventIdFactory, replicaDatabaseName, replicaTableName);
       break;
-
     case FULL_OVERWRITE:
     case FULL:
       Map<String, Object> mergedCopierOptions = tableReplication

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/replica/Replica.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/replica/Replica.java
@@ -304,13 +304,10 @@ public class Replica extends HiveEndpoint {
     TableAndStatistics replicaTable = tableFactory
         .newReplicaTable(eventId, sourceTable, replicaDatabaseName, replicaTableName, tableLocation, replicationMode);
 
-    // remove table here so the below doesnt give a table ?
     if (replicationMode == FULL_OVERWRITE) {
       dropReplicaTable(client, replicaDatabaseName, replicaTableName);
     }
-
     Optional<Table> oldReplicaTable = getTable(client, replicaDatabaseName, replicaTableName);
-
     if (!oldReplicaTable.isPresent()) {
       LOG.debug("No existing replica table found, creating.");
       try {
@@ -320,7 +317,6 @@ public class Replica extends HiveEndpoint {
         throw new MetaStoreClientException(
             "Unable to create replica table '" + replicaDatabaseName + "." + replicaTableName + "'", e);
       }
-
     } else {
       makeSureCanReplicate(oldReplicaTable.get(), replicaTable.getTable());
       LOG.debug("Existing replica table found, altering.");
@@ -332,7 +328,6 @@ public class Replica extends HiveEndpoint {
             "Unable to alter replica table '" + replicaDatabaseName + "." + replicaTableName + "'", e);
       }
     }
-
     return oldReplicaTable;
   }
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -29,6 +29,9 @@ import static org.mockito.Mockito.when;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
+import static com.hotels.bdp.circustrain.api.conf.ReplicationMode.FULL;
+import static com.hotels.bdp.circustrain.api.conf.ReplicationMode.FULL_OVERWRITE;
+import static com.hotels.bdp.circustrain.api.conf.ReplicationMode.METADATA_MIRROR;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -86,6 +89,7 @@ import com.hotels.bdp.circustrain.core.PartitionsAndStatistics;
 import com.hotels.bdp.circustrain.core.TableAndStatistics;
 import com.hotels.bdp.circustrain.core.replica.hive.AlterTableService;
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
+import com.hotels.hcommon.hive.metastore.exception.MetaStoreClientException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReplicaTest {
@@ -328,12 +332,48 @@ public class ReplicaTest {
     throws TException, IOException {
     try {
       existingReplicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "previousEventId");
-      existingReplicaTable.putToParameters(REPLICATION_MODE.parameterName(), ReplicationMode.FULL_OVERWRITE.name());
-      tableReplication.setReplicationMode(ReplicationMode.METADATA_MIRROR);
+      existingReplicaTable.putToParameters(REPLICATION_MODE.parameterName(), FULL_OVERWRITE.name());
+      tableReplication.setReplicationMode(METADATA_MIRROR);
       replica = newReplica(tableReplication);
       replica.validateReplicaTable(DB_NAME, TABLE_NAME);
       fail("Should have thrown InvalidReplicationModeException");
     } catch (InvalidReplicationModeException e) {
+      // Check that nothing was written to the metastore
+      verify(mockMetaStoreClient).getTable(DB_NAME, TABLE_NAME);
+      verify(mockMetaStoreClient).close();
+      verifyNoMoreInteractions(mockMetaStoreClient);
+    }
+  }
+
+  @Test
+  public void validateFullOverwriteReplicationOnExistingTableSucceeds() throws TException {
+    existingReplicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "previousEventId");
+    existingReplicaTable.putToParameters(REPLICATION_MODE.parameterName(), FULL.name());
+    tableReplication.setReplicationMode(FULL_OVERWRITE);
+
+    replica
+        .updateMetadata(EVENT_ID, tableAndStatistics,
+            new PartitionsAndStatistics(sourceTable.getPartitionKeys(), Collections.<Partition>emptyList(),
+                Collections.<String, List<ColumnStatisticsObj>>emptyMap()),
+            DB_NAME, TABLE_NAME, mockReplicaLocationManager);
+    verify(alterTableService).alterTable(eq(mockMetaStoreClient), eq(existingReplicaTable), any(Table.class));
+    verify(mockMetaStoreClient).updateTableColumnStatistics(columnStatistics);
+    verify(mockReplicaLocationManager, never()).addCleanUpLocation(anyString(), any(Path.class));
+  }
+
+  @Test
+  public void validateFullOverwriteReplicationWithoutExistingTableFails() throws MetaException, TException {
+    try {
+    when(mockMetaStoreClient.tableExists(DB_NAME, TABLE_NAME)).thenReturn(false);
+
+    tableReplication.setReplicationMode(FULL_OVERWRITE);
+    replica
+        .updateMetadata(EVENT_ID, tableAndStatistics,
+            new PartitionsAndStatistics(sourceTable.getPartitionKeys(), Collections.<Partition>emptyList(),
+                Collections.<String, List<ColumnStatisticsObj>>emptyMap()),
+            DB_NAME, TABLE_NAME, mockReplicaLocationManager);
+
+    } catch (MetaStoreClientException e) {
       // Check that nothing was written to the metastore
       verify(mockMetaStoreClient).getTable(DB_NAME, TABLE_NAME);
       verify(mockMetaStoreClient).close();

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -324,6 +324,24 @@ public class ReplicaTest {
   }
 
   @Test
+  public void validateReplicaTableMetadataMirrorOnExistingFullOverwriteReplicationTableFails()
+    throws TException, IOException {
+    try {
+      existingReplicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "previousEventId");
+      existingReplicaTable.putToParameters(REPLICATION_MODE.parameterName(), ReplicationMode.FULL_OVERWRITE.name());
+      tableReplication.setReplicationMode(ReplicationMode.METADATA_MIRROR);
+      replica = newReplica(tableReplication);
+      replica.validateReplicaTable(DB_NAME, TABLE_NAME);
+      fail("Should have thrown InvalidReplicationModeException");
+    } catch (InvalidReplicationModeException e) {
+      // Check that nothing was written to the metastore
+      verify(mockMetaStoreClient).getTable(DB_NAME, TABLE_NAME);
+      verify(mockMetaStoreClient).close();
+      verifyNoMoreInteractions(mockMetaStoreClient);
+    }
+  }
+
+  @Test
   public void alteringExistingPartitionedReplicaTableSucceeds() throws TException, IOException {
     when(mockMetaStoreClient
         .getPartitionsByNames(DB_NAME, TABLE_NAME, Lists.newArrayList("c=one/d=two", "c=three/d=four")))

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest/partitioned-single-table-full-overwrite.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest/partitioned-single-table-full-overwrite.yml
@@ -1,0 +1,9 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_p_managed
+      partition-filter: (continent='Europe' AND country='UK') OR (continent='Asia' AND country='China')
+    replica-table:
+      table-name: ct_table_p_managed_copy
+      table-location: ${circus-train-runner.replica-warehouse-uri}/${circus-train-runner.database-name}/ct_table_p_managed_copy

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest/unpartitioned-single-table-full-overwrite.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest/unpartitioned-single-table-full-overwrite.yml
@@ -1,0 +1,8 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_u_managed
+    replica-table:
+      table-name: ct_table_u_managed_copy
+      table-location: ${circus-train-runner.replica-warehouse-uri}/${circus-train-runner.database-name}/ct_table_u_managed_copy

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/partitioned-single-table-full-overwrite-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/partitioned-single-table-full-overwrite-replication.yml
@@ -1,0 +1,11 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_p_managed
+      partition-filter: (continent='Europe' AND country='UK') OR (continent='Asia' AND country='China')
+    replica-table:
+      table-name: ct_table_p_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_p_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-full-overwrite-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest/unpartitioned-single-table-full-overwrite-replication.yml
@@ -1,0 +1,10 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_u
+    replica-table:
+      table-name: ct_table_u_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-full-overwrite-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/partitioned-single-table-full-overwrite-replication.yml
@@ -1,0 +1,11 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_p_managed
+      partition-filter: (continent='Europe' AND country='UK') OR (continent='Asia' AND country='China')
+    replica-table:
+      table-name: ct_table_p_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_p_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks

--- a/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-full-overwrite-replication.yml
+++ b/circus-train-integration-tests/src/test/data/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest/unpartitioned-single-table-full-overwrite-replication.yml
@@ -1,0 +1,10 @@
+table-replications:
+  - replication-mode: FULL_OVERWRITE
+    source-table:
+      database-name: ${circus-train-runner.database-name}
+      table-name: ct_table_u
+    replica-table:
+      table-name: ct_table_u_copy
+      table-location: s3a://replica/${circus-train-runner.database-name}/ct_table_u_copy
+security:
+  credential-provider: jceks://file/${config-location}/aws.jceks

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
+import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.DATABASE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.SOURCE_ENCODED_TABLE;
@@ -848,6 +849,123 @@ public class CircusTrainHdfsHdfsIntegrationTest {
       }
     });
     runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void partitionedTableFullOverwrite() throws Exception {
+    helper.createManagedPartitionedTable(toUri(sourceWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
+    LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    // creating replicaTable with additional columns
+    final URI replicaLocation = toUri(replicaWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
+    TestUtils
+        .createPartitionedTable(replicaCatalog.client(), DATABASE, TARGET_PARTITIONED_MANAGED_TABLE, replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_MANAGED_TABLE);
+    // setting up parameters and additional columns
+    setupReplicaTable(replicaTable, false, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("partitioned-single-table-full-overwrite.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_MANAGED_TABLE);
+        assertThat(hiveTable.getDbName(), is(DATABASE));
+        assertThat(hiveTable.getTableName(), is(TARGET_PARTITIONED_MANAGED_TABLE));
+        assertThat(hiveTable.getParameters().get(REPLICATION_EVENT.parameterName()), startsWith("ctp-"));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(isExternalTable(hiveTable), is(true));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_MANAGED_TABLE, (short) 50);
+        assertThat(partitions.size(), is(2));
+        assertThat(partitions.get(0).getValues(), is(Arrays.asList("Asia", "China")));
+        assertThat(partitions.get(1).getValues(), is(Arrays.asList("Europe", "UK")));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void unpartitionedTableFullOverwrite() throws Exception {
+    helper.createManagedUnpartitionedTable(toUri(sourceWarehouseUri, DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
+    LOG.info(">>>> Table {} ", sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE));
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    // creating replicaTable
+    final URI replicaLocation = toUri(replicaWarehouseUri, DATABASE, SOURCE_MANAGED_UNPARTITIONED_TABLE);
+    TestUtils
+        .createUnpartitionedTable(replicaCatalog.client(), DATABASE, TARGET_UNPARTITIONED_MANAGED_TABLE,
+            replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_MANAGED_TABLE);
+    // setting up parameters and additional columns
+    setupReplicaTable(replicaTable, false, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("unpartitioned-single-table-full-overwrite.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_MANAGED_TABLE);
+        assertThat(hiveTable.getDbName(), is(DATABASE));
+        assertThat(hiveTable.getTableName(), is(TARGET_UNPARTITIONED_MANAGED_TABLE));
+        assertThat(hiveTable.getParameters().get(REPLICATION_EVENT.parameterName()), startsWith("ctt-"));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(isExternalTable(hiveTable), is(true));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  private void setupReplicaTable(Table replicaTable, boolean partitioned, URI replicaLocation) throws Exception {
+    setupRelicaParameters(replicaTable);
+    if (partitioned) {
+      addPartitionsToReplica(replicaTable, replicaLocation);
+    }
+  }
+
+  private void setupRelicaParameters(Table replicaTable) {
+    List<FieldSchema> columns = replicaTable.getSd().getCols();
+    columns.add(new FieldSchema("age", "int", ""));
+    columns.add(new FieldSchema("colour", "string", ""));
+    replicaTable.getSd().setCols(columns);
+    replicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "dummyEventID");
+    replicaTable.putToParameters("paramToUpdate", "update-me");
+  }
+
+  private void addPartitionsToReplica(Table replicaTable, URI replicaLocation) throws Exception {
+    URI partitionAmerica = URI.create(replicaLocation + "/dummyEventID/continent=America");
+    final URI partitionMexico = URI.create(partitionAmerica + "/country=Mexico");
+    replicaCatalog
+        .client()
+        .add_partitions(
+            Arrays.asList(newTablePartition(replicaTable, Arrays.asList("America", "Mexico"), partitionMexico)));
   }
 
   @Test

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
@@ -24,11 +24,14 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
+import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.DATABASE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PART_00000;
+import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.SOURCE_MANAGED_PARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.UNPARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.utils.TestUtils.DATA_COLUMNS;
+import static com.hotels.bdp.circustrain.integration.utils.TestUtils.newTablePartition;
 import static com.hotels.bdp.circustrain.integration.utils.TestUtils.toUri;
 import static com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3URIs.toAmazonS3URI;
 
@@ -36,10 +39,12 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.gaul.s3proxy.junit.S3ProxyRule;
@@ -323,6 +328,145 @@ public class CircusTrainHdfsS3IntegrationTest {
       }
     });
     runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void partitionedTableFullOverwrite() throws Exception {
+    helper.createManagedPartitionedTable(toUri(sourceWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
+
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    // creating replicaTable with additional columns and partitions
+    final URI replicaLocation = toUri("s3a://replica/", DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
+    TestUtils.createPartitionedTable(replicaCatalog.client(), DATABASE, TARGET_PARTITIONED_TABLE, replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_TABLE);
+    // setting up parameters, additional columns and partitions
+    setupReplicaTable(replicaTable, true, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("partitioned-single-table-full-overwrite-replication.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3MapReduceCpOptionsParser.S3_ENDPOINT_URI, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        // Assert location
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_TABLE);
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_PARTITIONED_TABLE);
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        assertThat(hiveTable.getParameters().get(REPLICATION_EVENT.parameterName()), startsWith("ctp-"));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(isExternalTable(hiveTable), is(true));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_TABLE, (short) 50);
+        assertThat(partitions.size(), is(2));
+        assertThat(partitions.get(0).getValues(), is(Arrays.asList("Asia", "China")));
+        assertThat(partitions.get(1).getValues(), is(Arrays.asList("Europe", "UK")));
+
+        // Assert table directory
+        List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
+        assertThat(replicaFiles.size(), is(2));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void unpartitionedTableFullOverwrite() throws Exception {
+    final URI sourceTableUri = toUri(sourceWarehouseUri, DATABASE, UNPARTITIONED_TABLE);
+    helper.createUnpartitionedTable(sourceTableUri);
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, UNPARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    // creating replicaTable
+    final URI replicaLocation = toUri(replicaWarehouseUri, DATABASE, UNPARTITIONED_TABLE);
+    TestUtils.createUnpartitionedTable(replicaCatalog.client(), DATABASE, TARGET_UNPARTITIONED_TABLE, replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+    // setting up parameters and additional columns
+    setupReplicaTable(replicaTable, false, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("unpartitioned-single-table-full-overwrite-replication.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3MapReduceCpOptionsParser.S3_ENDPOINT_URI, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        // Assert location
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+        String eventId = hiveTable.getParameters().get(REPLICATION_EVENT.parameterName());
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_UNPARTITIONED_TABLE + "/" + eventId);
+        assertThat(eventId, startsWith("ctt-"));
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+        
+        // Assert copied files
+        File dataFile = new File(sourceTableUri.getPath(), PART_00000);
+        String fileKeyRegex = String
+            .format("%s/%s/ctt-\\d{8}t\\d{6}.\\d{3}z-\\w{8}/%s", DATABASE, TARGET_UNPARTITIONED_TABLE, PART_00000);
+        List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
+        assertThat(replicaFiles.size(), is(1));
+        for (S3ObjectSummary objectSummary : replicaFiles) {
+          assertThat(objectSummary.getSize(), is(dataFile.length()));
+          assertThat(objectSummary.getKey().matches(fileKeyRegex), is(true));
+        }
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  private void setupReplicaTable(Table replicaTable, boolean partitioned, URI replicaLocation) throws Exception {
+    setupRelicaParameters(replicaTable);
+    if (partitioned) {
+      addPartitionsToReplica(replicaTable, replicaLocation);
+    }
+  }
+
+  private void setupRelicaParameters(Table replicaTable) {
+    List<FieldSchema> columns = replicaTable.getSd().getCols();
+    columns.add(new FieldSchema("age", "int", ""));
+    columns.add(new FieldSchema("colour", "string", ""));
+    replicaTable.getSd().setCols(columns);
+    replicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "dummyEventID");
+    replicaTable.putToParameters("paramToUpdate", "update-me");
+  }
+
+  private void addPartitionsToReplica(Table replicaTable, URI replicaLocation) throws Exception {
+    URI partitionAmerica = URI.create(replicaLocation + "/dummyEventID/continent=America");
+    final URI partitionMexico = URI.create(partitionAmerica + "/country=Mexico");
+    replicaCatalog
+        .client()
+        .add_partitions(
+            Arrays.asList(newTablePartition(replicaTable, Arrays.asList("America", "Mexico"), partitionMexico)));
   }
 
 }

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
@@ -23,11 +23,14 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
+import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.DATABASE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PART_00000;
+import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.SOURCE_MANAGED_PARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.UNPARTITIONED_TABLE;
 import static com.hotels.bdp.circustrain.integration.utils.TestUtils.DATA_COLUMNS;
+import static com.hotels.bdp.circustrain.integration.utils.TestUtils.newTablePartition;
 import static com.hotels.bdp.circustrain.integration.utils.TestUtils.toUri;
 import static com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3URIs.toAmazonS3URI;
 
@@ -35,11 +38,13 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.gaul.s3proxy.junit.S3ProxyRule;
@@ -101,6 +106,8 @@ public class CircusTrainS3S3IntegrationTest {
   private File replicaWarehouseUri;
   private File housekeepingDbLocation;
 
+  private IntegrationTestHelper helper;
+
   private String jceksLocation;
   private AmazonS3ClientFactory s3ClientFactory;
   private AmazonS3 s3Client;
@@ -111,6 +118,8 @@ public class CircusTrainS3S3IntegrationTest {
     replicaWarehouseUri = temporaryFolder.newFolder("replica-warehouse");
     temporaryFolder.newFolder("db");
     housekeepingDbLocation = new File(new File(temporaryFolder.getRoot(), "db"), "housekeeping");
+
+    helper = new IntegrationTestHelper(sourceCatalog.client());
 
     jceksLocation = String.format("jceks://file/%s/aws.jceks", dataFolder.getFolder().getAbsolutePath());
     Security security = new Security();
@@ -271,6 +280,141 @@ public class CircusTrainS3S3IntegrationTest {
       }
     });
     runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void partitionedTableFullOverwrite() throws Exception {
+    helper.createManagedPartitionedTable(toUri(sourceWarehouseUri, DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE));
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, SOURCE_MANAGED_PARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    final URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_PARTITIONED_TABLE);
+    TestUtils.createPartitionedTable(replicaCatalog.client(), DATABASE, TARGET_PARTITIONED_TABLE, replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_TABLE);
+
+    // setting up parameters, additional columns and partitions
+    setupReplicaTable(replicaTable, true, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("partitioned-single-table-full-overwrite-replication.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3S3CopierOptions.Keys.S3_ENDPOINT_URI.keyName(), s3Proxy.getUri().toString())
+        .sourceConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_PARTITIONED_TABLE);
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_PARTITIONED_TABLE);
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        assertThat(hiveTable.getParameters().get(REPLICATION_EVENT.parameterName()), startsWith("ctp-"));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+
+        List<Partition> partitions = replicaCatalog
+            .client()
+            .listPartitions(DATABASE, TARGET_PARTITIONED_TABLE, (short) -1);
+        assertThat(partitions.size(), is(2));
+        assertThat(partitions.get(0).getValues(), is(Arrays.asList("Asia", "China")));
+        assertThat(partitions.get(1).getValues(), is(Arrays.asList("Europe", "UK")));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  @Test
+  public void unpartitionedTableFullOverwrite() throws Exception {
+    final URI sourceTableLocation = toUri("s3a://source/", DATABASE, UNPARTITIONED_TABLE);
+    TestUtils.createUnpartitionedTable(sourceCatalog.client(), DATABASE, UNPARTITIONED_TABLE, sourceTableLocation);
+    // adjusting the sourceTable, mimicking the change we want to update
+    Table sourceTable = sourceCatalog.client().getTable(DATABASE, UNPARTITIONED_TABLE);
+    sourceTable.putToParameters("paramToUpdate", "updated");
+    sourceCatalog.client().alter_table(sourceTable.getDbName(), sourceTable.getTableName(), sourceTable);
+
+    final File dataFile = temporaryFolder.newFile();
+    FileUtils.writeStringToFile(dataFile, "1\trob\tbristol\n2\tsam\ttoronto\n");
+    String fileKey = String.format("%s/%s/%s", DATABASE, UNPARTITIONED_TABLE, PART_00000);
+    s3Client.putObject("source", fileKey, dataFile);
+
+    // creating replicaTable
+    final URI replicaLocation = toUri("s3a://replica/", DATABASE, UNPARTITIONED_TABLE);
+    TestUtils.createUnpartitionedTable(replicaCatalog.client(), DATABASE, TARGET_UNPARTITIONED_TABLE, replicaLocation);
+    Table replicaTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+    // setting up parameters and additional columns
+    setupReplicaTable(replicaTable, false, replicaLocation);
+    replicaCatalog.client().alter_table(replicaTable.getDbName(), replicaTable.getTableName(), replicaTable);
+
+    exit.expectSystemExitWithStatus(0);
+    File config = dataFolder.getFile("unpartitioned-single-table-full-overwrite-replication.yml");
+    CircusTrainRunner runner = CircusTrainRunner
+        .builder(DATABASE, sourceWarehouseUri, replicaWarehouseUri, housekeepingDbLocation)
+        .sourceMetaStore(sourceCatalog.getThriftConnectionUri(), sourceCatalog.connectionURL(),
+            sourceCatalog.driverClassName())
+        .replicaMetaStore(replicaCatalog.getThriftConnectionUri())
+        .copierOption(S3S3CopierOptions.Keys.S3_ENDPOINT_URI.keyName(), s3Proxy.getUri().toString())
+        .sourceConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ENDPOINT, s3Proxy.getUri().toString())
+        .replicaConfigurationProperty(ACCESS_KEY, s3Proxy.getAccessKey())
+        .replicaConfigurationProperty(SECRET_KEY, s3Proxy.getSecretKey())
+        .build();
+    exit.checkAssertionAfterwards(new Assertion() {
+      @Override
+      public void checkAssertion() throws Exception {
+        Table hiveTable = replicaCatalog.client().getTable(DATABASE, TARGET_UNPARTITIONED_TABLE);
+        String eventId = hiveTable.getParameters().get(REPLICATION_EVENT.parameterName());
+        URI replicaLocation = toUri("s3a://replica/", DATABASE, TARGET_UNPARTITIONED_TABLE + "/" + eventId);
+        assertThat(hiveTable.getSd().getLocation(), is(replicaLocation.toString()));
+        assertThat(eventId, startsWith("ctt-"));
+        assertThat(hiveTable.getParameters().get(REPLICATION_MODE.parameterName()), is("FULL_OVERWRITE"));
+        assertThat(hiveTable.getParameters().get("paramToUpdate"), is("updated"));
+        assertThat(hiveTable.getSd().getCols(), is(DATA_COLUMNS));
+
+        // Assert files copied from source
+        List<S3ObjectSummary> replicaFiles = TestUtils.listObjects(s3Client, "replica");
+        assertThat(replicaFiles.size(), is(1));
+        assertThat(replicaFiles.get(0).getSize(), is(dataFile.length()));
+        String fileKey = String
+            .format("%s/%s/%s/%s", DATABASE, TARGET_UNPARTITIONED_TABLE, eventId, PART_00000);
+        assertThat(replicaFiles.get(0).getKey(), is(fileKey));
+      }
+    });
+    runner.run(config.getAbsolutePath());
+  }
+
+  private void setupReplicaTable(Table replicaTable, boolean partitioned, URI replicaLocation) throws Exception {
+    setupRelicaParameters(replicaTable);
+    if (partitioned) {
+      addPartitionsToReplica(replicaTable, replicaLocation);
+    }
+  }
+
+  private void setupRelicaParameters(Table replicaTable) {
+    List<FieldSchema> columns = replicaTable.getSd().getCols();
+    columns.add(new FieldSchema("age", "int", ""));
+    columns.add(new FieldSchema("colour", "string", ""));
+    replicaTable.getSd().setCols(columns);
+    replicaTable.putToParameters(REPLICATION_EVENT.parameterName(), "dummyEventID");
+    replicaTable.putToParameters("paramToUpdate", "update-me");
+  }
+
+  private void addPartitionsToReplica(Table replicaTable, URI replicaLocation) throws Exception {
+    URI partitionAmerica = URI.create(replicaLocation + "/dummyEventID/continent=America");
+    final URI partitionMexico = URI.create(partitionAmerica + "/country=Mexico");
+    replicaCatalog
+        .client()
+        .add_partitions(
+            Arrays.asList(newTablePartition(replicaTable, Arrays.asList("America", "Mexico"), partitionMexico)));
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/circus-train/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Added a replication mode `FULL_OVERWRITE` which will overwrite an existing table with the source. The expected use for this mode would be early during the development cycle when the schema could be subject to incompatible changes. 

### :link: Related Issues
#183 