### PR TITLE
Copier context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Fix AssumeRoleCredentialProvider not auto-renewing credentials on expiration.
 
 ### Fixed
-* Fixed issue where replication breaks if struct columns have changed. com.hotels.bdp.circustrain.api.copier.CopierFactory
+* Fixed issue where replication breaks if struct columns have changed. See [#173](https://github.com/HotelsDotCom/circus-train/issues/173).
 
 ## [16.0.0] - 2020-02-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [16.3.0] - TBD
+### Added
+* Added method `newInstance(CopierContext)` to `com.hotels.bdp.circustrain.api.copier.CopierFactory`. This provides Copiers with more configuration information in a future proof manner. See [#195](https://github.com/HotelsDotCom/circus-train/issues/195).
+### Deprecated
+* Deprecated other `newInstance()` methods on `com.hotels.bdp.circustrain.api.copier.CopierFactory`.
+
 ## [16.2.0] - 2020-07-01
 ### Changed
 * Changed version of `hive.version` to `2.3.7` (was `2.3.2`). This allows Circus Train to be used on JDK>=9.
@@ -11,7 +17,7 @@
 * Fix AssumeRoleCredentialProvider not auto-renewing credentials on expiration.
 
 ### Fixed
-* Fixed issue where replication breaks if struct columns have changed. See [#173](https://github.com/HotelsDotCom/circus-train/issues/173).
+* Fixed issue where replication breaks if struct columns have changed. com.hotels.bdp.circustrain.api.copier.CopierFactory
 
 ## [16.0.0] - 2020-02-26
 ### Changed

--- a/circus-train-api/pom.xml
+++ b/circus-train-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-api</artifactId>

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 
@@ -82,26 +81,22 @@ public class CompositeCopierFactory implements CopierFactory {
   }
 
   @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      List<Path> sourceSubLocations,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
+  public Copier newInstance(CopierContext copierContext) {
     List<Copier> copiers = new ArrayList<>(delegates.size());
     int i = 0;
     for (CopierFactory delegate : delegates) {
-      CopierPathGeneratorParams copierPathGeneratorParams = CopierPathGeneratorParams.newParams(i++, eventId,
-          sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions);
+      CopierPathGeneratorParams copierPathGeneratorParams = CopierPathGeneratorParams.newParams(i++, copierContext.getEventId(),
+          copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(), copierContext.getCopierOptions());
       Path newSourceBaseLocation = pathGenerator.generateSourceBaseLocation(copierPathGeneratorParams);
       Path newReplicaLocation = pathGenerator.generateReplicaLocation(copierPathGeneratorParams);
-      Copier copier = delegate.newInstance(eventId, newSourceBaseLocation, sourceSubLocations, newReplicaLocation,
-          copierOptions);
+      
+      CopierContext delegateContext = new CopierContext(copierContext.getEventId(), newSourceBaseLocation, copierContext.getSourceSubLocations(), newReplicaLocation, copierContext.getCopierOptions());
+      Copier copier = delegate.newInstance(delegateContext);
       copiers.add(copier);
     }
     return new CompositeCopier(copiers, metricsMerger);
   }
-
+/*
   @Override
   public Copier newInstance(
       String eventId,
@@ -119,6 +114,6 @@ public class CompositeCopierFactory implements CopierFactory {
       copiers.add(copier);
     }
     return new CompositeCopier(copiers, metricsMerger);
-  }
+  }*/
 
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 
@@ -85,35 +86,41 @@ public class CompositeCopierFactory implements CopierFactory {
     List<Copier> copiers = new ArrayList<>(delegates.size());
     int i = 0;
     for (CopierFactory delegate : delegates) {
-      CopierPathGeneratorParams copierPathGeneratorParams = CopierPathGeneratorParams.newParams(i++, copierContext.getEventId(),
-          copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(), copierContext.getCopierOptions());
+      CopierPathGeneratorParams copierPathGeneratorParams = CopierPathGeneratorParams
+          .newParams(i++, copierContext.getEventId(), copierContext.getSourceBaseLocation(),
+              copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(),
+              copierContext.getCopierOptions());
       Path newSourceBaseLocation = pathGenerator.generateSourceBaseLocation(copierPathGeneratorParams);
       Path newReplicaLocation = pathGenerator.generateReplicaLocation(copierPathGeneratorParams);
-      
-      CopierContext delegateContext = new CopierContext(copierContext.getEventId(), newSourceBaseLocation, copierContext.getSourceSubLocations(), newReplicaLocation, copierContext.getCopierOptions());
+
+      CopierContext delegateContext = new CopierContext(copierContext.getEventId(), newSourceBaseLocation,
+          copierContext.getSourceSubLocations(), newReplicaLocation, copierContext.getCopierOptions());
       Copier copier = delegate.newInstance(delegateContext);
       copiers.add(copier);
     }
     return new CompositeCopier(copiers, metricsMerger);
   }
-/*
+
   @Override
   public Copier newInstance(
       String eventId,
       Path sourceBaseLocation,
       Path replicaLocation,
       Map<String, Object> copierOptions) {
-    List<Copier> copiers = new ArrayList<>(delegates.size());
-    int i = 0;
-    for (CopierFactory delegatee : delegates) {
-      CopierPathGeneratorParams copierPathGeneratorParams = CopierPathGeneratorParams.newParams(i++, eventId,
-          sourceBaseLocation, null, replicaLocation, copierOptions);
-      Path newReplicaLocation = pathGenerator.generateReplicaLocation(copierPathGeneratorParams);
-      Path newSourceBaseLocation = pathGenerator.generateSourceBaseLocation(copierPathGeneratorParams);
-      Copier copier = delegatee.newInstance(eventId, newSourceBaseLocation, newReplicaLocation, copierOptions);
-      copiers.add(copier);
-    }
-    return new CompositeCopier(copiers, metricsMerger);
-  }*/
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, replicaLocation, copierOptions);
+    return newInstance(copierContext);
+  }
+
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaLocation,
+        copierOptions);
+    return newInstance(copierContext);
+  }
 
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.bdp.circustrain.api.copier;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -26,28 +27,35 @@ public class CopierContext {
 
   private String eventId;
   private Path sourceBaseLocation;
-  private List<Path> sourceSubLocations;
+  private List<Path> sourceSubLocations = Collections.<Path>emptyList();
   private Path replicaLocation;
   private Map<String, Object> copierOptions;
   private TableReplication tableReplication;
-  private String sourceDatabaseName;
-  private String sourceTableName;
-  
-  //TODO: below constructor added to make it easier to construct these based on how we used to do it, probably replace with a builder instead.
-  public CopierContext(String eventId, Path sourceBaseLocation, List<Path> sourceSubLocations, Path replicaLocation, Map<String, Object> copierOptions) {
+
+  public CopierContext(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
     this.eventId = eventId;
     this.sourceBaseLocation = sourceBaseLocation;
     this.sourceSubLocations = sourceSubLocations;
     this.replicaLocation = replicaLocation;
     this.copierOptions = copierOptions;
   }
-  
-  public CopierContext(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions) {
+
+  public CopierContext(
+      String eventId,
+      Path sourceBaseLocation,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
     this.eventId = eventId;
     this.sourceBaseLocation = sourceBaseLocation;
     this.replicaLocation = replicaLocation;
     this.copierOptions = copierOptions;
   }
+
   public String getEventId() {
     return eventId;
   }
@@ -88,18 +96,12 @@ public class CopierContext {
     this.copierOptions = copierOptions;
   }
 
-  //TODO: decide on this 
   public void setTableReplication(TableReplication tableReplication) {
     this.tableReplication = tableReplication;
   }
-  //OR
-  public void setSourceDatabaseName(String sourceDatabaseName) {
-    this.sourceDatabaseName = sourceDatabaseName;
-    
+
+  public TableReplication getTableReplication() {
+    return tableReplication;
   }
-  public void setSourceTableName(String sourceTableName) {
-    this.sourceTableName = sourceTableName;    
-  }
-  
 
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2016-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.api.copier;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
+
+public class CopierContext {
+
+  private String eventId;
+  private Path sourceBaseLocation;
+  private List<Path> sourceSubLocations;
+  private Path replicaLocation;
+  private Map<String, Object> copierOptions;
+  private TableReplication tableReplication;
+  private String sourceDatabaseName;
+  private String sourceTableName;
+  
+  //TODO: below constructor added to make it easier to construct these based on how we used to do it, probably replace with a builder instead.
+  public CopierContext(String eventId, Path sourceBaseLocation, List<Path> sourceSubLocations, Path replicaLocation, Map<String, Object> copierOptions) {
+    this.eventId = eventId;
+    this.sourceBaseLocation = sourceBaseLocation;
+    this.sourceSubLocations = sourceSubLocations;
+    this.replicaLocation = replicaLocation;
+    this.copierOptions = copierOptions;
+  }
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public Path getSourceBaseLocation() {
+    return sourceBaseLocation;
+  }
+
+  public void setSourceBaseLocation(Path sourceBaseLocation) {
+    this.sourceBaseLocation = sourceBaseLocation;
+  }
+
+  public List<Path> getSourceSubLocations() {
+    return sourceSubLocations;
+  }
+
+  public void setSourceSubLocations(List<Path> sourceSubLocations) {
+    this.sourceSubLocations = sourceSubLocations;
+  }
+
+  public Path getReplicaLocation() {
+    return replicaLocation;
+  }
+
+  public void setReplicaLocation(Path replicaLocation) {
+    this.replicaLocation = replicaLocation;
+  }
+
+  public Map<String, Object> getCopierOptions() {
+    return copierOptions;
+  }
+
+  public void setCopierOptions(Map<String, Object> copierOptions) {
+    this.copierOptions = copierOptions;
+  }
+
+  //TODO: decide on this 
+  public void setTableReplication(TableReplication tableReplication) {
+    this.tableReplication = tableReplication;
+  }
+  //OR
+  public void setSourceDatabaseName(String sourceDatabaseName) {
+    this.sourceDatabaseName = sourceDatabaseName;
+    
+  }
+  public void setSourceTableName(String sourceTableName) {
+    this.sourceTableName = sourceTableName;    
+  }
+  
+
+}

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -41,6 +41,13 @@ public class CopierContext {
     this.replicaLocation = replicaLocation;
     this.copierOptions = copierOptions;
   }
+  
+  public CopierContext(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions) {
+    this.eventId = eventId;
+    this.sourceBaseLocation = sourceBaseLocation;
+    this.replicaLocation = replicaLocation;
+    this.copierOptions = copierOptions;
+  }
   public String getEventId() {
     return eventId;
   }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 
-public class CopierContext {
+public final class CopierContext {
 
   private String eventId;
   private Path sourceBaseLocation;

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -21,16 +21,45 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 
 public class CopierContext {
 
   private String eventId;
   private Path sourceBaseLocation;
-  private List<Path> sourceSubLocations = Collections.<Path>emptyList();
+  private List<Path> sourceSubLocations = ImmutableList.copyOf(Collections.<Path>emptyList());
   private Path replicaLocation;
   private Map<String, Object> copierOptions;
   private TableReplication tableReplication;
+
+  public CopierContext(
+      TableReplication tableReplication,
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    this.tableReplication = tableReplication;
+    this.eventId = eventId;
+    this.sourceBaseLocation = sourceBaseLocation;
+    if (sourceSubLocations != null) {
+      this.sourceSubLocations = ImmutableList.copyOf(sourceSubLocations);
+    }
+    this.replicaLocation = replicaLocation;
+    this.copierOptions = ImmutableMap.copyOf(copierOptions);
+  }
+
+  public CopierContext(
+      TableReplication tableReplication,
+      String eventId,
+      Path sourceLocation,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    this(tableReplication, eventId, sourceLocation, null, replicaLocation, copierOptions);
+  }
 
   public CopierContext(
       String eventId,
@@ -38,11 +67,7 @@ public class CopierContext {
       List<Path> sourceSubLocations,
       Path replicaLocation,
       Map<String, Object> copierOptions) {
-    this.eventId = eventId;
-    this.sourceBaseLocation = sourceBaseLocation;
-    this.sourceSubLocations = sourceSubLocations;
-    this.replicaLocation = replicaLocation;
-    this.copierOptions = copierOptions;
+    this(null, eventId, sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions);
   }
 
   public CopierContext(
@@ -50,54 +75,27 @@ public class CopierContext {
       Path sourceBaseLocation,
       Path replicaLocation,
       Map<String, Object> copierOptions) {
-    this.eventId = eventId;
-    this.sourceBaseLocation = sourceBaseLocation;
-    this.replicaLocation = replicaLocation;
-    this.copierOptions = copierOptions;
+    this(null, eventId, sourceBaseLocation, null, replicaLocation, copierOptions);
   }
 
   public String getEventId() {
     return eventId;
   }
 
-  public void setEventId(String eventId) {
-    this.eventId = eventId;
-  }
-
   public Path getSourceBaseLocation() {
     return sourceBaseLocation;
-  }
-
-  public void setSourceBaseLocation(Path sourceBaseLocation) {
-    this.sourceBaseLocation = sourceBaseLocation;
   }
 
   public List<Path> getSourceSubLocations() {
     return sourceSubLocations;
   }
 
-  public void setSourceSubLocations(List<Path> sourceSubLocations) {
-    this.sourceSubLocations = sourceSubLocations;
-  }
-
   public Path getReplicaLocation() {
     return replicaLocation;
   }
 
-  public void setReplicaLocation(Path replicaLocation) {
-    this.replicaLocation = replicaLocation;
-  }
-
   public Map<String, Object> getCopierOptions() {
     return copierOptions;
-  }
-
-  public void setCopierOptions(Map<String, Object> copierOptions) {
-    this.copierOptions = copierOptions;
-  }
-
-  public void setTableReplication(TableReplication tableReplication) {
-    this.tableReplication = tableReplication;
   }
 
   public TableReplication getTableReplication() {

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  */
 package com.hotels.bdp.circustrain.api.copier;
 
-import java.util.List;
-import java.util.Map;
 
-import org.apache.hadoop.fs.Path;
 
 public interface CopierFactory {
 
   boolean supportsSchemes(String sourceScheme, String replicaScheme);
 
+  //TODO: copier context builder which checks that the below are filled in as they are required
+  
+  Copier newInstance(CopierContext copierContext);
+  
   /**
    * @param eventId
    * @param sourceBaseLocation
@@ -32,12 +33,12 @@ public interface CopierFactory {
    * @param copierOptions, contains both global and per table override configured options
    * @return
    */
-  Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      List<Path> sourceSubLocations,
-      Path replicaLocation,
-      Map<String, Object> copierOptions);
+//  Copier newInstance(
+//      String eventId,
+//      Path sourceBaseLocation,
+//      List<Path> sourceSubLocations,
+//      Path replicaLocation,
+//      Map<String, Object> copierOptions);
 
   /**
    * @param eventId
@@ -46,6 +47,6 @@ public interface CopierFactory {
    * @param copierOptions, contains both global and per table override configured options
    * @return
    */
-  Copier newInstance(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions);
+  //Copier newInstance(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions);
 
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
@@ -15,17 +15,30 @@
  */
 package com.hotels.bdp.circustrain.api.copier;
 
+import java.util.List;
+import java.util.Map;
 
+import org.apache.hadoop.fs.Path;
 
 public interface CopierFactory {
 
   boolean supportsSchemes(String sourceScheme, String replicaScheme);
 
-  //TODO: copier context builder which checks that the below are filled in as they are required
-  
-  Copier newInstance(CopierContext copierContext);
-  
   /**
+   * Creates a new Copier.
+   * 
+   * @param copierContext Context object containing configuration values for the Copier.
+   * @return
+   */
+  default Copier newInstance(CopierContext copierContext) {
+    //TODO: this is only here for backwards compatibility with CopierFactorys using older versions of Circus Train, when the below
+    //deprecated methods are removed so should this default implementation
+    return newInstance(copierContext.getEventId(), copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(), 
+        copierContext.getCopierOptions());
+  }
+
+  /**
+   * @deprecated As of release 16.3.0, replaced by {@link #newInstance(CopierContext)}.
    * @param eventId
    * @param sourceBaseLocation
    * @param sourceSubLocations
@@ -33,20 +46,24 @@ public interface CopierFactory {
    * @param copierOptions, contains both global and per table override configured options
    * @return
    */
-//  Copier newInstance(
-//      String eventId,
-//      Path sourceBaseLocation,
-//      List<Path> sourceSubLocations,
-//      Path replicaLocation,
-//      Map<String, Object> copierOptions);
+  @Deprecated
+  Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions);
 
   /**
+   * @deprecated As of release 16.3.0, replaced by {@link #newInstance(CopierContext)}.
+   * 
    * @param eventId
    * @param sourceBaseLocation
    * @param replicaLocation
    * @param copierOptions, contains both global and per table override configured options
    * @return
    */
-  //Copier newInstance(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions);
+  @Deprecated
+  Copier newInstance(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions);
 
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorParams.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorParams.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 
 public class CopierPathGeneratorParams {
 
-  //TODO: should we change this to take the CopierContext instead of the arguments after copierIndex?
   public static CopierPathGeneratorParams newParams(
       int copierIndex,
       String eventId,

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorParams.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorParams.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 
 public class CopierPathGeneratorParams {
 
+  //TODO: should we change this to take the CopierContext instead of the arguments after copierIndex?
   public static CopierPathGeneratorParams newParams(
       int copierIndex,
       String eventId,

--- a/circus-train-avro/pom.xml
+++ b/circus-train-avro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-avro</artifactId>

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
@@ -75,7 +75,7 @@ public class SchemaCopier {
     CopierFactory copierFactory = copierFactoryManager
         .getCopierFactory(sourceLocation, destinationSchemaFile, mergedCopierOptions);
     LOG.info("Replicating Avro schema from '{}' to '{}'", sourceLocation, destinationSchemaFile);
-    CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, destinationSchemaFile, mergedCopierOptions);
+    CopierContext copierContext = new CopierContext(eventId, sourceLocation, destinationSchemaFile, mergedCopierOptions);
     Copier copier = copierFactory.newInstance(copierContext);
     Metrics metrics = copier.copy();
 

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
@@ -74,7 +75,9 @@ public class SchemaCopier {
     CopierFactory copierFactory = copierFactoryManager
         .getCopierFactory(sourceLocation, destinationSchemaFile, mergedCopierOptions);
     LOG.info("Replicating Avro schema from '{}' to '{}'", sourceLocation, destinationSchemaFile);
-    Copier copier = copierFactory.newInstance(eventId, sourceLocation, destinationSchemaFile, mergedCopierOptions);
+    //TODO: check but I don't think we care about now having db name, table name etc. for this copier
+    CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, destinationSchemaFile, mergedCopierOptions);
+    Copier copier = copierFactory.newInstance(copierContext);
     Metrics metrics = copier.copy();
 
     LOG

--- a/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
+++ b/circus-train-avro/src/main/java/com/hotels/bdp/circustrain/avro/util/SchemaCopier.java
@@ -75,7 +75,6 @@ public class SchemaCopier {
     CopierFactory copierFactory = copierFactoryManager
         .getCopierFactory(sourceLocation, destinationSchemaFile, mergedCopierOptions);
     LOG.info("Replicating Avro schema from '{}' to '{}'", sourceLocation, destinationSchemaFile);
-    //TODO: check but I don't think we care about now having db name, table name etc. for this copier
     CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, destinationSchemaFile, mergedCopierOptions);
     Copier copier = copierFactory.newInstance(copierContext);
     Metrics metrics = copier.copy();

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -73,9 +72,7 @@ public class SchemaCopierTest {
     copierOptionsMap.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
     when(copierFactoryManager.getCopierFactory(eq(source), eq(targetFile), eq(copierOptionsMap)))
         .thenReturn(copierFactory);
-    //when(copierFactory.newInstance(eq(eventId), eq(source), eq(targetFile), eq(copierOptionsMap))).thenReturn(copier);
-    //TODO: looks like above specifically returns the mock copier only on certain input, need to do the same based on the context
-    doReturn(copier).when(copierFactory.newInstance(any(CopierContext.class)));
+    when(copierFactory.newInstance(any(CopierContext.class))).thenReturn(copier);
     when(copier.copy()).thenReturn(metrics);
     when(metrics.getBytesReplicated()).thenReturn(123L);
     Path result = schemaCopier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
@@ -17,7 +17,9 @@ package com.hotels.bdp.circustrain.avro.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -36,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.copier.CopierOptions;
@@ -70,7 +73,9 @@ public class SchemaCopierTest {
     copierOptionsMap.put(CopierOptions.COPY_DESTINATION_IS_FILE, "true");
     when(copierFactoryManager.getCopierFactory(eq(source), eq(targetFile), eq(copierOptionsMap)))
         .thenReturn(copierFactory);
-    when(copierFactory.newInstance(eq(eventId), eq(source), eq(targetFile), eq(copierOptionsMap))).thenReturn(copier);
+    //when(copierFactory.newInstance(eq(eventId), eq(source), eq(targetFile), eq(copierOptionsMap))).thenReturn(copier);
+    //TODO: looks like above specifically returns the mock copier only on certain input, need to do the same based on the context
+    doReturn(copier).when(copierFactory.newInstance(any(CopierContext.class)));
     when(copier.copy()).thenReturn(metrics);
     when(metrics.getBytesReplicated()).thenReturn(123L);
     Path result = schemaCopier.copy(source.toString(), destination.toString(), eventTableReplication, eventId);

--- a/circus-train-aws-sns/pom.xml
+++ b/circus-train-aws-sns/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/circus-train-aws/pom.xml
+++ b/circus-train-aws/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-aws</artifactId>

--- a/circus-train-common-test/pom.xml
+++ b/circus-train-common-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-common-test</artifactId>

--- a/circus-train-comparator/pom.xml
+++ b/circus-train-comparator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparator</artifactId>

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-core</artifactId>

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
@@ -28,6 +28,7 @@ import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
 import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
@@ -53,37 +54,30 @@ class PartitionedTableReplication implements Replication {
   private final String eventId;
   private final CopierFactoryManager copierFactoryManager;
   private final PartitionPredicate partitionPredicate;
-  private final String targetTableLocation;
-  private final String replicaDatabaseName;
-  private final String replicaTableName;
   private Metrics metrics = Metrics.NULL_VALUE;
   private final Map<String, Object> copierOptions;
   private final CopierListener copierListener;
   private final DataManipulatorFactoryManager dataManipulatorFactoryManager;
 
+  private TableReplication tableReplication;
+
   PartitionedTableReplication(
-      String database,
-      String table,
+      TableReplication tableReplication,
       PartitionPredicate partitionPredicate,
       Source source,
       Replica replica,
       CopierFactoryManager copierFactoryManager,
       EventIdFactory eventIdFactory,
-      String targetTableLocation,
-      String replicaDatabaseName,
-      String replicaTableName,
       Map<String, Object> copierOptions,
       CopierListener copierListener,
       DataManipulatorFactoryManager dataManipulatorFactoryManager) {
-    this.database = database;
-    this.table = table;
+    this.tableReplication = tableReplication;
+    this.database = tableReplication.getSourceTable().getDatabaseName();
+    this.table = tableReplication.getSourceTable().getTableName();
     this.partitionPredicate = partitionPredicate;
     this.source = source;
     this.replica = replica;
     this.copierFactoryManager = copierFactoryManager;
-    this.targetTableLocation = targetTableLocation;
-    this.replicaDatabaseName = replicaDatabaseName;
-    this.replicaTableName = replicaTableName;
     this.copierOptions = copierOptions;
     this.copierListener = copierListener;
     this.dataManipulatorFactoryManager = dataManipulatorFactoryManager;
@@ -93,6 +87,9 @@ class PartitionedTableReplication implements Replication {
   @Override
   public void replicate() throws CircusTrainException {
     try {
+      String replicaDatabaseName = tableReplication.getReplicaDatabaseName();
+      String replicaTableName = tableReplication.getReplicaTableName();
+
       TableAndStatistics sourceTableAndStatistics = source.getTableAndStatistics(database, table);
       Table sourceTable = sourceTableAndStatistics.getTable();
 
@@ -110,7 +107,8 @@ class PartitionedTableReplication implements Replication {
       List<Path> sourceSubLocations = sourceLocationManager.getPartitionLocations();
 
       ReplicaLocationManager replicaLocationManager = replica
-          .getLocationManager(TableType.PARTITIONED, targetTableLocation, eventId, sourceLocationManager);
+          .getLocationManager(TableType.PARTITIONED, tableReplication.getReplicaTable().getTableLocation(), eventId,
+              sourceLocationManager);
       Path replicaPartitionBaseLocation = replicaLocationManager.getPartitionBaseLocation();
 
       DataManipulatorFactory dataManipulatorFactory = dataManipulatorFactoryManager
@@ -129,10 +127,10 @@ class PartitionedTableReplication implements Replication {
       } else {
         CopierFactory copierFactory = copierFactoryManager
             .getCopierFactory(sourceBaseLocation, replicaPartitionBaseLocation, copierOptions);
-        //TODO: here we could add db and table name, or look into how to get the TableReplication object
-        CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaPartitionBaseLocation, copierOptions);
-        Copier copier = copierFactory
-            .newInstance(copierContext);
+        CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations,
+            replicaPartitionBaseLocation, copierOptions);
+        copierContext.setTableReplication(tableReplication);
+        Copier copier = copierFactory.newInstance(copierContext);
         copierListener.copierStart(copier.getClass().getName());
         try {
           metrics = copier.copy();

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
@@ -29,6 +29,7 @@ import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.data.DataManipulator;
@@ -128,8 +129,10 @@ class PartitionedTableReplication implements Replication {
       } else {
         CopierFactory copierFactory = copierFactoryManager
             .getCopierFactory(sourceBaseLocation, replicaPartitionBaseLocation, copierOptions);
+        //TODO: here we could add db and table name, or look into how to get the TableReplication object
+        CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaPartitionBaseLocation, copierOptions);
         Copier copier = copierFactory
-            .newInstance(eventId, sourceBaseLocation, sourceSubLocations, replicaPartitionBaseLocation, copierOptions);
+            .newInstance(copierContext);
         copierListener.copierStart(copier.getClass().getName());
         try {
           metrics = copier.copy();

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
@@ -127,9 +127,8 @@ class PartitionedTableReplication implements Replication {
       } else {
         CopierFactory copierFactory = copierFactoryManager
             .getCopierFactory(sourceBaseLocation, replicaPartitionBaseLocation, copierOptions);
-        CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations,
+        CopierContext copierContext = new CopierContext(tableReplication, eventId, sourceBaseLocation, sourceSubLocations,
             replicaPartitionBaseLocation, copierOptions);
-        copierContext.setTableReplication(tableReplication);
         Copier copier = copierFactory.newInstance(copierContext);
         copierListener.copierStart(copier.getClass().getName());
         try {

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -75,10 +75,6 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
     String sourceDatabaseName = sourceTable.getDatabaseName();
     String sourceTableName = sourceTable.getTableName();
 
-    String replicaDatabaseName = tableReplication.getReplicaDatabaseName();
-    String replicaTableName = tableReplication.getReplicaTableName();
-    String replicaTableLocation = tableReplication.getReplicaTable().getTableLocation();
-
     Source source = sourceFactory.newInstance(tableReplication);
     validate(tableReplication, source, replica);
     TableAndStatistics tableAndStatistics = source.getTableAndStatistics(sourceDatabaseName, sourceTableName);

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImpl.java
@@ -105,11 +105,8 @@ public class ReplicationFactoryImpl implements ReplicationFactory {
     case FULL:
       Map<String, Object> mergedCopierOptions = tableReplication
           .getMergedCopierOptions(copierOptions.getCopierOptions());
-      replication = new PartitionedTableReplication(tableReplication.getSourceTable().getDatabaseName(),
-          tableReplication.getSourceTable().getTableName(), partitionPredicate, source, replica, copierFactoryManager,
-          eventIdFactory, tableReplication.getReplicaTable().getTableLocation(),
-          tableReplication.getReplicaDatabaseName(), tableReplication.getReplicaTableName(), mergedCopierOptions,
-          copierListener, dataManipulatorFactoryManager);
+      replication = new PartitionedTableReplication(tableReplication, partitionPredicate, source, replica,
+          copierFactoryManager, eventIdFactory, mergedCopierOptions, copierListener, dataManipulatorFactoryManager);
       break;
     case METADATA_UPDATE:
       replication = new PartitionedTableMetadataUpdateReplication(tableReplication.getSourceTable().getDatabaseName(),

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -98,11 +98,7 @@ class UnpartitionedTableReplication implements Replication {
           .getCopierFactory(sourceLocation, replicaLocation, copierOptions);
       
       CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, replicaLocation, copierOptions);
-      //TODO: below which requires passing tableReplication around
       copierContext.setTableReplication(tableReplication);
-      //OR below which requires less messing around in the ReplicationFactoryImpl but is possibly more future proof
-      copierContext.setSourceDatabaseName(database);
-      copierContext.setSourceTableName(table);
       
       Copier copier = copierFactory.newInstance(copierContext);
       copierListener.copierStart(copier.getClass().getName());

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -97,7 +97,7 @@ class UnpartitionedTableReplication implements Replication {
       CopierFactory copierFactory = copierFactoryManager
           .getCopierFactory(sourceLocation, replicaLocation, copierOptions);
       
-      CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, replicaLocation, copierOptions);
+      CopierContext copierContext = new CopierContext(eventId, sourceLocation, replicaLocation, copierOptions);
       copierContext.setTableReplication(tableReplication);
       
       Copier copier = copierFactory.newInstance(copierContext);

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -97,9 +97,7 @@ class UnpartitionedTableReplication implements Replication {
       CopierFactory copierFactory = copierFactoryManager
           .getCopierFactory(sourceLocation, replicaLocation, copierOptions);
       
-      CopierContext copierContext = new CopierContext(eventId, sourceLocation, replicaLocation, copierOptions);
-      copierContext.setTableReplication(tableReplication);
-      
+      CopierContext copierContext = new CopierContext(tableReplication, eventId, sourceLocation, replicaLocation, copierOptions);
       Copier copier = copierFactory.newInstance(copierContext);
       copierListener.copierStart(copier.getClass().getName());
       try {

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -26,7 +26,9 @@ import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.Replication;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.api.copier.CopierFactoryManager;
 import com.hotels.bdp.circustrain.api.data.DataManipulator;
@@ -49,35 +51,28 @@ class UnpartitionedTableReplication implements Replication {
   private final Replica replica;
   private final String eventId;
   private final CopierFactoryManager copierFactoryManager;
-  private final String targetTableLocation;
-  private final String replicaDatabaseName;
-  private final String replicaTableName;
   private Metrics metrics = Metrics.NULL_VALUE;
   private final Map<String, Object> copierOptions;
   private final CopierListener copierListener;
   private final DataManipulatorFactoryManager dataManipulatorFactoryManager;
 
+  private TableReplication tableReplication;
+
   UnpartitionedTableReplication(
-      String database,
-      String table,
+      TableReplication tableReplication,
       Source source,
       Replica replica,
       CopierFactoryManager copierFactoryManager,
       EventIdFactory eventIdFactory,
-      String targetTableLocation,
-      String replicaDatabaseName,
-      String replicaTableName,
       Map<String, Object> copierOptions,
       CopierListener copierListener,
       DataManipulatorFactoryManager dataManipulatorFactoryManager) {
-    this.database = database;
-    this.table = table;
+    this.tableReplication = tableReplication;
+    this.database = tableReplication.getSourceTable().getDatabaseName();
+    this.table = tableReplication.getSourceTable().getTableName();
     this.source = source;
     this.replica = replica;
     this.copierFactoryManager = copierFactoryManager;
-    this.targetTableLocation = targetTableLocation;
-    this.replicaDatabaseName = replicaDatabaseName;
-    this.replicaTableName = replicaTableName;
     this.copierOptions = copierOptions;
     this.copierListener = copierListener;
     this.dataManipulatorFactoryManager = dataManipulatorFactoryManager;
@@ -87,6 +82,8 @@ class UnpartitionedTableReplication implements Replication {
   @Override
   public void replicate() throws CircusTrainException {
     try {
+      String replicaDatabaseName = tableReplication.getReplicaDatabaseName();
+      String replicaTableName = tableReplication.getReplicaTableName();
       replica.validateReplicaTable(replicaDatabaseName, replicaTableName);
       TableAndStatistics sourceTableAndStatistics = source.getTableAndStatistics(database, table);
       Table sourceTable = sourceTableAndStatistics.getTable();
@@ -94,12 +91,20 @@ class UnpartitionedTableReplication implements Replication {
       Path sourceLocation = sourceLocationManager.getTableLocation();
 
       ReplicaLocationManager replicaLocationManager = replica
-          .getLocationManager(TableType.UNPARTITIONED, targetTableLocation, eventId, sourceLocationManager);
+          .getLocationManager(TableType.UNPARTITIONED, tableReplication.getReplicaTable().getTableLocation(), eventId, sourceLocationManager);
       Path replicaLocation = replicaLocationManager.getTableLocation();
 
       CopierFactory copierFactory = copierFactoryManager
           .getCopierFactory(sourceLocation, replicaLocation, copierOptions);
-      Copier copier = copierFactory.newInstance(eventId, sourceLocation, replicaLocation, copierOptions);
+      
+      CopierContext copierContext = new CopierContext(eventId, sourceLocation, null, replicaLocation, copierOptions);
+      //TODO: below which requires passing tableReplication around
+      copierContext.setTableReplication(tableReplication);
+      //OR below which requires less messing around in the ReplicationFactoryImpl but is possibly more future proof
+      copierContext.setSourceDatabaseName(database);
+      copierContext.setSourceTableName(table);
+      
+      Copier copier = copierFactory.newInstance(copierContext);
       copierListener.copierStart(copier.getClass().getName());
       try {
         metrics = copier.copy();

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/TableReplicationUtils.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/TableReplicationUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2016-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.circustrain.core;
+
+import com.hotels.bdp.circustrain.api.conf.ReplicaTable;
+import com.hotels.bdp.circustrain.api.conf.SourceTable;
+import com.hotels.bdp.circustrain.api.conf.TableReplication;
+
+public final class TableReplicationUtils {
+
+  private TableReplicationUtils() {};
+
+  protected static TableReplication createTableReplication(
+      String sourceDatabaseName,
+      String sourceTableName,
+      String replicaDatabaseName,
+      String replicateTableName,
+      String targetTableLocation) {
+    TableReplication tableReplication = new TableReplication();
+    ReplicaTable replicaTable = new ReplicaTable();
+    replicaTable.setDatabaseName(replicaDatabaseName);
+    replicaTable.setTableName(replicateTableName);
+    replicaTable.setTableLocation(targetTableLocation);
+    tableReplication.setReplicaTable(replicaTable);
+    SourceTable sourceTable = new SourceTable();
+    sourceTable.setDatabaseName(sourceDatabaseName);
+    sourceTable.setTableName(sourceTableName);
+    tableReplication.setSourceTable(sourceTable);
+    return tableReplication;
+  }
+
+}

--- a/circus-train-distcp-copier/pom.xml
+++ b/circus-train-distcp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-distcp-copier</artifactId>

--- a/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
+++ b/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
@@ -15,8 +15,11 @@
  */
 package com.hotels.bdp.circustrain.distcpcopier;
 
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -57,10 +60,26 @@ public class DistCpCopierFactory implements CopierFactory {
   }
 
   // TODO: difference between null and Collections.<Path>emptyList() for sourceSubLocations
-  /*
-   * @Override public Copier newInstance( String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String,
-   * Object> copierOptions) { return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(),
-   * replicaLocation, copierOptions); }
-   */
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, replicaLocation, copierOptions);
+    return newInstance(copierContext);
+  }
+
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaLocation,
+        copierOptions);
+    return newInstance(copierContext);
+  }
 
 }

--- a/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
+++ b/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,8 @@
  */
 package com.hotels.bdp.circustrain.distcpcopier;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -32,6 +28,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 
 @Profile({ Modules.REPLICATION })
@@ -54,23 +51,16 @@ public class DistCpCopierFactory implements CopierFactory {
   }
 
   @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      List<Path> sourceSubLocations,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
-    return new DistCpCopier(conf, sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions,
-        runningMetricsRegistry);
+  public Copier newInstance(CopierContext copierContext) {
+    return new DistCpCopier(conf, copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(),
+        copierContext.getReplicaLocation(), copierContext.getCopierOptions(), runningMetricsRegistry);
   }
 
-  @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
-    return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
-  }
+  // TODO: difference between null and Collections.<Path>emptyList() for sourceSubLocations
+  /*
+   * @Override public Copier newInstance( String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String,
+   * Object> copierOptions) { return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(),
+   * replicaLocation, copierOptions); }
+   */
 
 }

--- a/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
+++ b/circus-train-distcp-copier/src/main/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactory.java
@@ -59,7 +59,6 @@ public class DistCpCopierFactory implements CopierFactory {
         copierContext.getReplicaLocation(), copierContext.getCopierOptions(), runningMetricsRegistry);
   }
 
-  // TODO: difference between null and Collections.<Path>emptyList() for sourceSubLocations
   @Override
   public Copier newInstance(
       String eventId,

--- a/circus-train-gcp/pom.xml
+++ b/circus-train-gcp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-gcp</artifactId>

--- a/circus-train-hive-view/pom.xml
+++ b/circus-train-hive-view/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive-view</artifactId>

--- a/circus-train-hive/pom.xml
+++ b/circus-train-hive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive</artifactId>

--- a/circus-train-housekeeping/pom.xml
+++ b/circus-train-housekeeping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-housekeeping</artifactId>

--- a/circus-train-integration-tests/pom.xml
+++ b/circus-train-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-integration-tests</artifactId>

--- a/circus-train-metrics/pom.xml
+++ b/circus-train-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-metrics</artifactId>

--- a/circus-train-package/pom.xml
+++ b/circus-train-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/pom.xml
+++ b/circus-train-s3-mapreduce-cp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp-copier</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactory.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactory.java
@@ -15,8 +15,11 @@
  */
 package com.hotels.bdp.circustrain.s3mapreducecpcopier;
 
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -58,13 +61,26 @@ public class S3MapReduceCpCopierFactory implements CopierFactory {
         copierContext.getReplicaLocation(), copierContext.getCopierOptions(), runningMetricsRegistry);
   }
 
-  // @Override
-  // public Copier newInstance(
-  // String eventId,
-  // Path sourceBaseLocation,
-  // Path replicaLocation,
-  // Map<String, Object> copierOptions) {
-  // return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
-  // }
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, replicaLocation, copierOptions);
+    return newInstance(copierContext);
+  }
+
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaLocation,
+        copierOptions);
+    return newInstance(copierContext);
+  }
 
 }

--- a/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactory.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/main/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,8 @@
  */
 package com.hotels.bdp.circustrain.s3mapreducecpcopier;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -32,6 +28,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.aws.S3Schemes;
 
@@ -56,23 +53,18 @@ public class S3MapReduceCpCopierFactory implements CopierFactory {
   }
 
   @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      List<Path> sourceSubLocations,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
-    return new S3MapReduceCpCopier(conf, sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions,
-        runningMetricsRegistry);
+  public Copier newInstance(CopierContext copierContext) {
+    return new S3MapReduceCpCopier(conf, copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(),
+        copierContext.getReplicaLocation(), copierContext.getCopierOptions(), runningMetricsRegistry);
   }
 
-  @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
-    return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
-  }
+  // @Override
+  // public Copier newInstance(
+  // String eventId,
+  // Path sourceBaseLocation,
+  // Path replicaLocation,
+  // Map<String, Object> copierOptions) {
+  // return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
+  // }
 
 }

--- a/circus-train-s3-mapreduce-cp/pom.xml
+++ b/circus-train-s3-mapreduce-cp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp</artifactId>

--- a/circus-train-s3-s3-copier/pom.xml
+++ b/circus-train-s3-s3-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-s3-copier</artifactId>

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package com.hotels.bdp.circustrain.s3s3copier;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
-import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
@@ -30,6 +26,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.api.copier.Copier;
+import com.hotels.bdp.circustrain.api.copier.CopierContext;
 import com.hotels.bdp.circustrain.api.copier.CopierFactory;
 import com.hotels.bdp.circustrain.aws.S3Schemes;
 import com.hotels.bdp.circustrain.s3s3copier.aws.AmazonS3ClientFactory;
@@ -64,24 +61,19 @@ public class S3S3CopierFactory implements CopierFactory {
   }
 
   @Override
-  public Copier newInstance(
-      String eventId,
-      Path sourceBaseLocation,
-      List<Path> sourceSubLocations,
-      Path replicaLocation,
-      Map<String, Object> copierOptions) {
-    return new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, clientFactory,
+  public Copier newInstance(CopierContext copierContext) {
+    return new S3S3Copier(copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(), clientFactory,
         transferManagerFactory, listObjectsRequestFactory, runningMetricsRegistry,
-        new S3S3CopierOptions(copierOptions));
+        new S3S3CopierOptions(copierContext.getCopierOptions()));
   }
 
-  @Override
+ /* @Override
   public Copier newInstance(
       String eventId,
       Path sourceBaseLocation,
       Path replicaLocation,
       Map<String, Object> copierOptions) {
     return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
-  }
+  }*/
 
 }

--- a/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
+++ b/circus-train-s3-s3-copier/src/main/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactory.java
@@ -15,7 +15,10 @@
  */
 package com.hotels.bdp.circustrain.s3s3copier;
 
+import java.util.List;
+import java.util.Map;
 
+import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
@@ -62,18 +65,31 @@ public class S3S3CopierFactory implements CopierFactory {
 
   @Override
   public Copier newInstance(CopierContext copierContext) {
-    return new S3S3Copier(copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(), copierContext.getReplicaLocation(), clientFactory,
-        transferManagerFactory, listObjectsRequestFactory, runningMetricsRegistry,
-        new S3S3CopierOptions(copierContext.getCopierOptions()));
+    return new S3S3Copier(copierContext.getSourceBaseLocation(), copierContext.getSourceSubLocations(),
+        copierContext.getReplicaLocation(), clientFactory, transferManagerFactory, listObjectsRequestFactory,
+        runningMetricsRegistry, new S3S3CopierOptions(copierContext.getCopierOptions()));
   }
 
- /* @Override
+  @Override
   public Copier newInstance(
       String eventId,
       Path sourceBaseLocation,
       Path replicaLocation,
       Map<String, Object> copierOptions) {
-    return newInstance(eventId, sourceBaseLocation, Collections.<Path>emptyList(), replicaLocation, copierOptions);
-  }*/
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, replicaLocation, copierOptions);
+    return newInstance(copierContext);
+  }
+
+  @Override
+  public Copier newInstance(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    CopierContext copierContext = new CopierContext(eventId, sourceBaseLocation, sourceSubLocations, replicaLocation,
+        copierOptions);
+    return newInstance(copierContext);
+  }
 
 }

--- a/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparison-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-filter-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-filter-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-filter-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-tool-core/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-core</artifactId>

--- a/circus-train-tool-parent/circus-train-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool</artifactId>

--- a/circus-train-tool-parent/pom.xml
+++ b/circus-train-tool-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.2.1-SNAPSHOT</version>
+    <version>16.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>circus-train-parent</artifactId>
   <description>circus-train replicates data and hive metadata between various clusters</description>
-  <version>16.2.1-SNAPSHOT</version>
+  <version>16.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Circus Train Parent</name>
   <inceptionYear>2016</inceptionYear>


### PR DESCRIPTION
Fixes #195 

This PR introduces a `CopierContext` class to hold the values that were being passed to the `CopierFactory` before, and then adds a `TableReplication` to this which in turns holds the additional values that were requested in the issue (source database and table names). This allows us to add more values to CopierContext in the past without breaking backwards compatibility which is the situation we're currently in due to the interface methods directly containing the values as arguments.

The changes in this PR are currently backwards-compatible by using a default method in the `CopierFactory` interface but I'll add some comments on this as another option would be to make a backwards *incompatible* change as it's quite easy to resolve downstream.