### PR TITLE
Added source table and partitions to CopierContext

### DIFF
--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactory.java
@@ -53,7 +53,6 @@ public class CompositeCopierFactory implements CopierFactory {
       }
       return metrics;
     }
-
   }
 
   private final List<CopierFactory> delegates;
@@ -94,7 +93,8 @@ public class CompositeCopierFactory implements CopierFactory {
       Path newReplicaLocation = pathGenerator.generateReplicaLocation(copierPathGeneratorParams);
 
       CopierContext delegateContext = new CopierContext(copierContext.getEventId(), newSourceBaseLocation,
-          copierContext.getSourceSubLocations(), newReplicaLocation, copierContext.getCopierOptions());
+          copierContext.getSourceSubLocations(), newReplicaLocation, copierContext.getCopierOptions(),
+          copierContext.getSourceTable(), copierContext.getSourcePartitions());
       Copier copier = delegate.newInstance(delegateContext);
       copiers.add(copier);
     }
@@ -122,5 +122,4 @@ public class CompositeCopierFactory implements CopierFactory {
         copierOptions);
     return newInstance(copierContext);
   }
-
 }

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierContext.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -34,6 +36,8 @@ public final class CopierContext {
   private Path replicaLocation;
   private Map<String, Object> copierOptions;
   private TableReplication tableReplication;
+  private Table sourceTable;
+  private List<Partition> sourcePartitions;
 
   public CopierContext(
       TableReplication tableReplication,
@@ -41,7 +45,9 @@ public final class CopierContext {
       Path sourceBaseLocation,
       List<Path> sourceSubLocations,
       Path replicaLocation,
-      Map<String, Object> copierOptions) {
+      Map<String, Object> copierOptions,
+      Table sourceTable,
+      List<Partition> sourcePartitions) {
     this.tableReplication = tableReplication;
     this.eventId = eventId;
     this.sourceBaseLocation = sourceBaseLocation;
@@ -50,6 +56,40 @@ public final class CopierContext {
     }
     this.replicaLocation = replicaLocation;
     this.copierOptions = ImmutableMap.copyOf(copierOptions);
+    this.sourceTable = sourceTable;
+    this.sourcePartitions = sourcePartitions;
+  }
+
+  public CopierContext(
+      TableReplication tableReplication,
+      String eventId,
+      Path sourceLocation,
+      Path replicaLocation,
+      Map<String, Object> copierOptions,
+      Table sourceTable) {
+    this(tableReplication, eventId, sourceLocation, null, replicaLocation, copierOptions, sourceTable, null);
+  }
+
+  public CopierContext(
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions,
+      Table sourceTable,
+      List<Partition> sourcePartitions) {
+    this(null, eventId, sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions, sourceTable,
+        sourcePartitions);
+  }
+
+  public CopierContext(
+      TableReplication tableReplication,
+      String eventId,
+      Path sourceBaseLocation,
+      List<Path> sourceSubLocations,
+      Path replicaLocation,
+      Map<String, Object> copierOptions) {
+    this(tableReplication, eventId, sourceBaseLocation, sourceSubLocations, replicaLocation, copierOptions, null, null);
   }
 
   public CopierContext(
@@ -102,4 +142,11 @@ public final class CopierContext {
     return tableReplication;
   }
 
+  public Table getSourceTable() {
+    return sourceTable;
+  }
+
+  public List<Partition> getSourcePartitions() {
+    return sourcePartitions;
+  }
 }

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/PartitionedTableReplication.java
@@ -128,7 +128,7 @@ class PartitionedTableReplication implements Replication {
         CopierFactory copierFactory = copierFactoryManager
             .getCopierFactory(sourceBaseLocation, replicaPartitionBaseLocation, copierOptions);
         CopierContext copierContext = new CopierContext(tableReplication, eventId, sourceBaseLocation, sourceSubLocations,
-            replicaPartitionBaseLocation, copierOptions);
+            replicaPartitionBaseLocation, copierOptions, sourceTable, sourcePartitions);
         Copier copier = copierFactory.newInstance(copierContext);
         copierListener.copierStart(copier.getClass().getName());
         try {

--- a/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
+++ b/circus-train-core/src/main/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplication.java
@@ -97,7 +97,7 @@ class UnpartitionedTableReplication implements Replication {
       CopierFactory copierFactory = copierFactoryManager
           .getCopierFactory(sourceLocation, replicaLocation, copierOptions);
       
-      CopierContext copierContext = new CopierContext(tableReplication, eventId, sourceLocation, replicaLocation, copierOptions);
+      CopierContext copierContext = new CopierContext(tableReplication, eventId, sourceLocation, replicaLocation, copierOptions, sourceTable);
       Copier copier = copierFactory.newInstance(copierContext);
       copierListener.copierStart(copier.getClass().getName());
       try {


### PR DESCRIPTION
Adding `Table sourceTable` and `List<Partition> sourcePartitions` to `CopierContext` in order to propagate table and partition filter information down to the copiers.