### PR TITLE
replace set-env with GITHUB_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
              echo "Coveralls token available"
              COVERALLS_SKIP=false
           fi
-          echo ::set-env name=COVERALLS_SKIP::${COVERALLS_SKIP}
+          echo "COVERALLS_SKIP=${COVERALLS_SKIP}" >> $GITHUB_ENV
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Based on https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files I think this is what we need to do to get this working again.