### PR TITLE
Get build working on Java 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ jobs:
   test:
     name: Package and run all tests
     runs-on: ubuntu-18.04
+    
+    strategy:
+      matrix:
+        java-version: [ 8, 11 ]
+    
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,6 +31,6 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: ${{ matrix.java-version }}
     - name: Run Maven Targets
       run: mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [16.4.0] - TBD
+### Changed
+* Various code changes to allow compilation and build on Java 11.
+* `hotels-oss-parent` version to 6.2.1 (was 5.0.0).
+
 ## [16.3.3] - 2020-12-10
 ### Fixed
 * Issue where rename table operation would be incorrect if tables are in different databases.

--- a/circus-train-api/pom.xml
+++ b/circus-train-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-api</artifactId>

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/copier/CopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public interface CopierFactory {
    * Creates a new Copier.
    * 
    * @param copierContext Context object containing configuration values for the Copier.
-   * @return
+   * @return A new Copier.
    */
   default Copier newInstance(CopierContext copierContext) {
     //TODO: this is only here for backwards compatibility with CopierFactorys using older versions of Circus Train, when the below
@@ -43,8 +43,7 @@ public interface CopierFactory {
    * @param sourceBaseLocation
    * @param sourceSubLocations
    * @param replicaLocation
-   * @param copierOptions, contains both global and per table override configured options
-   * @return
+   * @return A new Copier.
    */
   @Deprecated
   Copier newInstance(
@@ -60,8 +59,8 @@ public interface CopierFactory {
    * @param eventId
    * @param sourceBaseLocation
    * @param replicaLocation
-   * @param copierOptions, contains both global and per table override configured options
-   * @return
+   * @param copierOptions Contains both global and per table override configured options
+   * @return A new Copier.
    */
   @Deprecated
   Copier newInstance(String eventId, Path sourceBaseLocation, Path replicaLocation, Map<String, Object> copierOptions);

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.bdp.circustrain.api.event;
 
+import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 
 public interface CopierListener {

--- a/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
+++ b/circus-train-api/src/main/java/com/hotels/bdp/circustrain/api/event/CopierListener.java
@@ -15,20 +15,19 @@
  */
 package com.hotels.bdp.circustrain.api.event;
 
-import com.hotels.bdp.circustrain.api.copier.Copier;
 import com.hotels.bdp.circustrain.api.metrics.Metrics;
 
 public interface CopierListener {
 
   /**
-   * Is guaranteed to be called before a {@link Copier#copy()} is called.
+   * Is guaranteed to be called before a {@link com.hotels.bdp.circustrain.api.copier.Copier#copy()} is called.
    *
    * @param copierImplementation
    */
   void copierStart(String copierImplementation);
 
   /**
-   * Is guaranteed to be called when {@link Copier#copy()} is finished (even when {@link Copier#copy()} throws
+   * Is guaranteed to be called when {@link com.hotels.bdp.circustrain.api.copier.Copier#copy()} is finished (even when {@link com.hotels.bdp.circustrain.api.copier.Copier#copy()} throws
    * exceptions).
    *
    * @param metrics

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/ReplicaCatalogTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/ReplicaCatalogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Set;
 

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/SourceCatalogTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/SourceCatalogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Set;
 

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/SourceTableTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/SourceTableTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Set;
 

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/TableReplicationTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/conf/TableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.api.conf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactoryTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CompositeCopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.api.copier;
 import static java.util.Arrays.asList;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CompositeCopierFactoryTest {

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CopierContextTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CopierContextTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.hotels.bdp.circustrain.api.copier;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/CopierPathGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.copier;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.fs.Path;
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CopierPathGeneratorTest {

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/MetricsMergerTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/copier/MetricsMergerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 package com.hotels.bdp.circustrain.api.copier;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/ColumnStatisticsTransformationTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/ColumnStatisticsTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.metadata;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/PartitionTransformationTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/PartitionTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.metadata;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/TableTransformationTest.java
+++ b/circus-train-api/src/test/java/com/hotels/bdp/circustrain/api/metadata/TableTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.api.metadata;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/circus-train-avro/pom.xml
+++ b/circus-train-avro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-avro</artifactId>

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/hive/HiveObjectUtilsTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/hive/HiveObjectUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.avro.hive;
 
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import static junit.framework.TestCase.assertTrue;
 

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AbstractAvroSerDeTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.avro.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import static com.hotels.bdp.circustrain.avro.conf.AvroSerDeConfig.AVRO_SERDE_OPTIONS;
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.TransformOptions;
 import com.hotels.bdp.circustrain.api.event.EventReplicaTable;

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDePartitionTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.avro.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.TransformOptions;
 import com.hotels.bdp.circustrain.api.event.EventReplicaTable;

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTableTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.avro.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.TransformOptions;
 import com.hotels.bdp.circustrain.api.event.EventReplicaTable;

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTransformationTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/transformation/AvroSerDeTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.avro.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static junit.framework.TestCase.assertTrue;
 
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AvroSerDeTransformationTest {

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtilsTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/AvroStringUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package com.hotels.bdp.circustrain.avro.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static com.hotels.bdp.circustrain.avro.util.AvroStringUtils.appendForwardSlashIfNotPresent;

--- a/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
+++ b/circus-train-avro/src/test/java/com/hotels/bdp/circustrain/avro/util/SchemaCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.avro.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.io.Files;
 

--- a/circus-train-aws-sns/pom.xml
+++ b/circus-train-aws-sns/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -8,7 +10,8 @@
   </parent>
 
   <properties>
-    <!-- Needs to be different from the normal circus train shaded prefix otherwise we'll have conflicts with that jar -->
+    <!-- Needs to be different from the normal circus train shaded prefix 
+      otherwise we'll have conflicts with that jar -->
     <shade.prefix>${project.groupId}.snsshaded</shade.prefix>
   </properties>
 
@@ -25,6 +28,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
 
     <!-- Spring -->
@@ -96,8 +105,8 @@
               <shadedClassifierName>all</shadedClassifierName>
               <artifactSet>
                 <includes>
-                  <!-- our own jars need to be shaded + aws jars (+ deps) as they can conflict with provided jar when running
-                    on AWS -->
+                  <!-- our own jars need to be shaded + aws jars (+ deps) 
+                    as they can conflict with provided jar when running on AWS -->
                   <include>com.hotels:circus-train-aws-sns</include>
                   <include>com.amazonaws:*</include>
                   <include>org.apache.httpcomponents:*</include>
@@ -109,8 +118,9 @@
                   <pattern>com.amazonaws</pattern>
                   <shadedPattern>${shade.prefix}.com.amazonaws</shadedPattern>
                 </relocation>
-                <relocation><!-- Note org.apache.httpcomponents groupId but org.apache.http package, this is relocated due
-                    to newer version used by com.amazonaws, older version is provided by /usr/lib/hive/ -->
+                <relocation><!-- Note org.apache.httpcomponents groupId but 
+                    org.apache.http package, this is relocated due to newer version used by com.amazonaws, 
+                    older version is provided by /usr/lib/hive/ -->
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
                 </relocation>

--- a/circus-train-aws-sns/pom.xml
+++ b/circus-train-aws-sns/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/ListenerConfigTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/ListenerConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/ListenerConfigTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/ListenerConfigTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.aws.sns.event;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfigurationTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.sns.AmazonSNS;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -55,7 +54,6 @@ public class SnsConfigurationTest {
   @Test
   public void snsClient() {
     AWSCredentialsProvider credentialsProvider = mock(AWSCredentialsProvider.class);
-    when(credentialsProvider.getCredentials()).thenReturn(new BasicAWSCredentials("accessKey", "secretKey"));
     ListenerConfig config = new ListenerConfig();
     config.setRegion("eu-west-1");
     AmazonSNS sns = configuration.amazonSNS(config, credentialsProvider);

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfigurationTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsConfigurationTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.aws.sns.event;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +28,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListenerTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListenerTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.aws.sns.event;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 import com.amazonaws.services.sns.model.PublishRequest;

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListenerTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,10 +101,8 @@ public class SnsListenerTest {
     when(config.getStartTopic()).thenReturn("startArn");
     when(config.getSuccessTopic()).thenReturn("successArn");
     when(config.getFailTopic()).thenReturn("failArn");
-    when(config.getTopic()).thenReturn("topicArn");
     when(config.getSubject()).thenReturn(SUBJECT);
     when(config.getHeaders()).thenReturn(headers);
-    when(config.getQueueSize()).thenReturn(10);
 
     when(replicaTable.getTableLocation()).thenReturn(REPLICA_TABLE_LOCATION);
     when(tableReplication.getSourceTable()).thenReturn(sourceTable);

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsMessageTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsMessageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsMessageTest.java
+++ b/circus-train-aws-sns/src/test/java/com/hotels/bdp/circustrain/aws/sns/event/SnsMessageTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.aws.sns.event;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/circus-train-aws/pom.xml
+++ b/circus-train-aws/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-aws</artifactId>

--- a/circus-train-aws/pom.xml
+++ b/circus-train-aws/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -36,10 +38,17 @@
     </dependency>
 
     <!-- Test -->
+
     <dependency>
       <groupId>com.hotels</groupId>
       <artifactId>circus-train-common-test</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/AmazonS3URIsTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/AmazonS3URIsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.aws;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/CannedAclUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.aws;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/JceksAWSCredentialProviderTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/JceksAWSCredentialProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,6 @@ public class JceksAWSCredentialProviderTest {
 
   @Test(expected = IllegalStateException.class)
   public void accessKeyNotSetInConfThrowsException() throws Exception {
-    when(conf.getPassword(AWSConstants.SECRET_KEY)).thenReturn("secretKey".toCharArray());
     new JceksAWSCredentialProvider(conf).getCredentials();
   }
 

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/JceksAWSCredentialProviderTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/JceksAWSCredentialProviderTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.aws;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -26,7 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import fm.last.commons.test.file.ClassDataFolder;
 

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/S3DataManipulatorTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/S3DataManipulatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;

--- a/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/context/AWSBeanPostProcessorTest.java
+++ b/circus-train-aws/src/test/java/com/hotels/bdp/circustrain/aws/context/AWSBeanPostProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.aws.context;
 
 import static org.apache.hadoop.security.alias.CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.aws.BindS3AFileSystem;
 import com.hotels.bdp.circustrain.aws.S3CredentialsUtils;

--- a/circus-train-common-test/pom.xml
+++ b/circus-train-common-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-common-test</artifactId>

--- a/circus-train-common-test/src/test/java/com/hotels/bdp/circustrain/common/test/junit/rules/ServerSocketRuleTest.java
+++ b/circus-train-common-test/src/test/java/com/hotels/bdp/circustrain/common/test/junit/rules/ServerSocketRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.common.test.junit.rules;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.ConnectException;
 import java.net.Socket;

--- a/circus-train-comparator/pom.xml
+++ b/circus-train-comparator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparator</artifactId>

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/ComparatorRegistryTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/ComparatorRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package com.hotels.bdp.circustrain.comparator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/comparator/AbstractComparatorTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/comparator/AbstractComparatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 package com.hotels.bdp.circustrain.comparator.comparator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.comparator.ComparatorRegistry;
 import com.hotels.bdp.circustrain.comparator.api.ComparatorType;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/HiveDifferencesIntegrationTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/HiveDifferencesIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/HiveDifferencesTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/HiveDifferencesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.hotels.bdp.circustrain.comparator.hive;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -44,7 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/FieldSchemaComparatorTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/FieldSchemaComparatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.comparator.hive.comparator;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.comparator.TestUtils.newPropertyDiff;
 import static com.hotels.bdp.circustrain.comparator.api.ComparatorType.FULL_COMPARISON;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/PartitionAndMetadataComparatorTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/PartitionAndMetadataComparatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.comparator.hive.comparator;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.comparator.TestUtils.newDiff;
 import static com.hotels.bdp.circustrain.comparator.TestUtils.newPartition;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/TableAndMetadataComparatorTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/comparator/TableAndMetadataComparatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.comparator.hive.comparator;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.comparator.TestUtils.newDiff;
 import static com.hotels.bdp.circustrain.comparator.TestUtils.newPropertyDiff;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/CleanPartitionFunctionTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/CleanPartitionFunctionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.comparator.TestUtils.COLS;
 import static com.hotels.bdp.circustrain.comparator.TestUtils.CREATE_TIME;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/CleanTableFunctionTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/CleanTableFunctionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.comparator.TestUtils.COLS;
 import static com.hotels.bdp.circustrain.comparator.TestUtils.CREATE_TIME;

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathDigestTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathDigestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableList;
 

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -32,7 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.io.Files;
 

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.comparator.hive.functions;
 
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.comparator.hive.wrappers.PathMetadata;
 

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/hive/functions/PathToPathMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ public class PathToPathMetadataTest {
     when(path.toUri()).thenReturn(new URI(DIR_PATH));
     when(path.getFileSystem(any(Configuration.class))).thenReturn(fs);
 
-    when(fileStatus.getPath()).thenReturn(path);
     when(fileStatus.getModificationTime()).thenReturn(LAST_MODIFIED);
     when(fs.getFileStatus(path)).thenReturn(fileStatus);
 

--- a/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/listener/PartitionSpecCreatingDiffListenerTest.java
+++ b/circus-train-comparator/src/test/java/com/hotels/bdp/circustrain/comparator/listener/PartitionSpecCreatingDiffListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.comparator.listener;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -161,14 +161,6 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
     </dependency>

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-core</artifactId>

--- a/circus-train-core/pom.xml
+++ b/circus-train-core/pom.xml
@@ -166,7 +166,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainHelpTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainHelpTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/CircusTrainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static com.google.common.base.Charsets.UTF_8;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/ConfigFileValidationApplicationListenerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/ConfigFileValidationApplicationListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.core.env.ConfigurableEnvironment;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DefaultCopierFactoryManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DestructiveReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DestructiveReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DiffGeneratedPartitionPredicateTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/DiffGeneratedPartitionPredicateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
@@ -43,7 +43,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/EventIdFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/EventIdFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/HiveEndpointTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/HiveEndpointTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -42,7 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/HiveEndpointTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/HiveEndpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,8 +193,6 @@ public class HiveEndpointTest {
   @Test
   public void getPartitionsWithoutFilter() throws Exception {
     when(metaStoreClient.listPartitions(DATABASE, TABLE, (short) MAX_PARTITIONS)).thenReturn(partitions);
-    when(metaStoreClient.getPartitionColumnStatistics(DATABASE, TABLE, PARTITION_NAMES, COLUMN_NAMES))
-        .thenReturn(partitionStatsMap);
 
     PartitionsAndStatistics partitionsAndStatistics = hiveEndpoint.getPartitions(table, null, MAX_PARTITIONS);
     assertThat(partitionsAndStatistics.getPartitions(), is(partitions));

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/LocomotiveTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/LocomotiveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.ApplicationArguments;
 
 import com.hotels.bdp.circustrain.api.CompletionCode;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionPredicateFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionPredicateFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.fs.Path;
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Function;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableMetadataMirrorReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableMetadataMirrorReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableMetadataUpdateReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableMetadataUpdateReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,6 +85,7 @@ public class PartitionedTableReplicationTest {
   private @Mock DataManipulatorFactoryManager dataManipulatorFactoryManager;
   private @Mock DataManipulatorFactory dataManipulatorFactory;
   private @Mock DataManipulator dataManipulator;
+  private @Mock Metrics metrics;
 
   private final Path sourceTableLocation = new Path("sourceTableLocation");
   private final Path replicaTableLocation = new Path("replicaTableLocation");
@@ -107,12 +109,12 @@ public class PartitionedTableReplicationTest {
         .thenReturn(copierFactory);
     when(copierFactory.newInstance(any(CopierContext.class))).thenReturn(copier);
     when(partitionsAndStatistics.getPartitions()).thenReturn(sourcePartitions);
-    when(copierOptions.get("task-count")).thenReturn(Integer.valueOf(2));
     when(partitionPredicate.getPartitionPredicate()).thenReturn(PARTITION_PREDICATE);
     when(partitionPredicate.getPartitionPredicateLimit()).thenReturn(MAX_PARTITIONS);
     when(dataManipulatorFactoryManager.getFactory(sourceTableLocation, replicaTableLocation, copierOptions))
         .thenReturn(dataManipulatorFactory);
     when(dataManipulatorFactory.newInstance(replicaTableLocation, copierOptions)).thenReturn(dataManipulator);
+    when(copier.copy()).thenReturn(metrics);
   }
 
   @Test
@@ -158,7 +160,7 @@ public class PartitionedTableReplicationTest {
     replicationOrder.verify(copierFactory).newInstance(any(CopierContext.class));
     replicationOrder.verify(listener).copierStart(anyString());
     replicationOrder.verify(copier).copy();
-    replicationOrder.verify(listener).copierEnd(any(Metrics.class));
+    replicationOrder.verify(listener).copierEnd(metrics);
     replicationOrder.verify(sourceLocationManager).cleanUpLocations();
     replicationOrder
         .verify(replica)
@@ -239,7 +241,7 @@ public class PartitionedTableReplicationTest {
       replicationOrder.verify(listener).copierStart(anyString());
       replicationOrder.verify(copier).copy();
       // Still called
-      replicationOrder.verify(listener).copierEnd(any(Metrics.class));
+      replicationOrder.verify(listener).copierEnd(metrics);
     }
   }
 }

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionedTableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionsAndStatisticsTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/PartitionsAndStatisticsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import static com.hotels.bdp.circustrain.core.metastore.HiveEntityFactory.newFieldSchema;
 import static com.hotels.bdp.circustrain.core.metastore.HiveEntityFactory.newPartition;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImplTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/ReplicationFactoryImplTest.java
@@ -16,9 +16,9 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.Replication;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/SpelParsedPartitionPredicateTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/SpelParsedPartitionPredicateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 package com.hotels.bdp.circustrain.core;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.SourceTable;
 import com.hotels.bdp.circustrain.api.conf.TableReplication;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/StrategyBasedReplicationFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/StrategyBasedReplicationFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package com.hotels.bdp.circustrain.core;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataMirrorReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataMirrorReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;
 import com.hotels.bdp.circustrain.api.SourceLocationManager;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataUpdateReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataUpdateReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,6 @@ public class UnpartitionedTableMetadataUpdateReplicationTest {
   public void injectMocks() throws Exception {
     when(eventIdFactory.newEventId(anyString())).thenReturn(EVENT_ID);
     when(source.getTableAndStatistics(DATABASE, TABLE)).thenReturn(sourceTableAndStatistics);
-    when(sourceTableAndStatistics.getTable()).thenReturn(sourceTable);
     when(replica.getMetaStoreClientSupplier()).thenReturn(supplier);
     when(supplier.get()).thenReturn(client);
   }

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataUpdateReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableMetadataUpdateReplicationTest.java
@@ -31,7 +31,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,8 @@ public class UnpartitionedTableReplicationTest {
   private DataManipulatorFactory dataManipulatorFactory;
   @Mock
   private DataManipulator dataManipulator;
+  @Mock
+  private  Metrics metrics;
 
   private final Path sourceTableLocation = new Path("sourceTableLocation");
   private final Path replicaTableLocation = new Path("replicaTableLocation");
@@ -108,6 +110,7 @@ public class UnpartitionedTableReplicationTest {
     when(dataManipulatorFactoryManager.getFactory(sourceTableLocation, replicaTableLocation, copierOptions))
         .thenReturn(dataManipulatorFactory);
     when(dataManipulatorFactory.newInstance(replicaTableLocation, copierOptions)).thenReturn(dataManipulator);
+    when(copier.copy()).thenReturn(metrics);
   }
 
   private TableReplication createTypicalTableReplication() {
@@ -133,7 +136,7 @@ public class UnpartitionedTableReplicationTest {
     replicationOrder.verify(copierFactory).newInstance(any(CopierContext.class));
     replicationOrder.verify(listener).copierStart(anyString());
     replicationOrder.verify(copier).copy();
-    replicationOrder.verify(listener).copierEnd(any(Metrics.class));
+    replicationOrder.verify(listener).copierEnd(metrics);
     replicationOrder.verify(sourceLocationManager).cleanUpLocations();
     replicationOrder
         .verify(replica)

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/UnpartitionedTableReplicationTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 import com.hotels.bdp.circustrain.api.ReplicaLocationManager;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/ExpressionParserFunctionsTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/ExpressionParserFunctionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/ReplicaCatalogIntegrationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/ReplicaCatalogIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.core.conf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/SourceCatalogIntegrationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/SourceCatalogIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.google.common.base.Charsets.UTF_8;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/SpringExpressionParserTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/conf/SpringExpressionParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/data/DefaultDataManipulatorFactoryManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/data/DefaultDataManipulatorFactoryManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.data.DataManipulator;
 import com.hotels.bdp.circustrain.api.data.DataManipulatorFactory;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/EventUtilsTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/EventUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package com.hotels.bdp.circustrain.core.event;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -36,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableList;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/LoggingListenerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/LoggingListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.event;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.event.EventPartition;
 import com.hotels.bdp.circustrain.api.event.EventPartitions;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/MetricsListenerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/event/MetricsListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.core.event;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.ScheduledReporter;
 import com.google.common.collect.ImmutableMap;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/AddCheckSumReplicaTableFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/AddCheckSumReplicaTableFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.PARTITION_CHECKSUM;
@@ -37,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/CleanupLocationManagerFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/CleanupLocationManagerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package com.hotels.bdp.circustrain.core.replica;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.OrphanedDataStrategy;
 import com.hotels.bdp.circustrain.api.conf.ReplicaTable;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/DestructiveReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/DestructiveReplicaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,7 +172,6 @@ public class DestructiveReplicaTest {
 
   @Test
   public void dropDeletedPartitionsNothingToDrop() throws Exception {
-    when(client.getTable(DATABASE, REPLICA_TABLE)).thenReturn(table);
     Partition replicaPartition = new Partition();
     replicaPartition.setValues(Lists.newArrayList("value1"));
 
@@ -192,7 +191,6 @@ public class DestructiveReplicaTest {
   @Test
   public void dropDeletedPartitionsUnpartitionedTable() throws Exception {
     table.setPartitionKeys(null);
-    when(client.getTable(DATABASE, REPLICA_TABLE)).thenReturn(table);
 
     List<String> sourcePartitionNames = Lists.newArrayList();
     replica.dropDeletedPartitions(sourcePartitionNames);

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/DestructiveReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/DestructiveReplicaTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyShort;
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/FullReplicationReplicaLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/FullReplicationReplicaLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 import com.hotels.bdp.circustrain.api.event.ReplicaCatalogListener;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/HousekeepingCleanupLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/HousekeepingCleanupLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/MetadataMirrorReplicaLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/MetadataMirrorReplicaLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.fs.Path;
@@ -26,7 +26,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.SourceLocationManager;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/MetadataUpdateReplicaLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/MetadataUpdateReplicaLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTableFactoryProviderTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTableFactoryProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.fs.Path;
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Function;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTableFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTableFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.core.replica;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static com.hotels.bdp.circustrain.api.conf.ReplicationMode.FULL;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -72,7 +72,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/ReplicaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package com.hotels.bdp.circustrain.core.replica;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -168,7 +169,6 @@ public class ReplicaTest {
     existingReplicaTable = new Table(sourceTable);
 
     when(mockReplicaLocationManager.getTableLocation()).thenReturn(new Path(tableLocation));
-    when(mockReplicaLocationManager.getPartitionBaseLocation()).thenReturn(new Path(tableLocation));
 
     when(mockMetaStoreClient.getTable(DB_NAME, TABLE_NAME)).thenReturn(existingReplicaTable);
   }
@@ -180,7 +180,6 @@ public class ReplicaTest {
 
   private void convertExistingReplicaTableToView() {
     when(mockReplicaLocationManager.getTableLocation()).thenReturn(null);
-    when(mockReplicaLocationManager.getPartitionBaseLocation()).thenReturn(null);
     existingReplicaTable.setTableType(TableType.VIRTUAL_VIEW.name());
     existingReplicaTable.getSd().setLocation(null);
     existingPartition.getSd().setLocation(null);
@@ -405,9 +404,6 @@ public class ReplicaTest {
 
   @Test
   public void alteringExistingPartitionedReplicaTableSucceeds() throws Exception, IOException {
-    when(mockMetaStoreClient
-        .getPartitionsByNames(DB_NAME, TABLE_NAME, Lists.newArrayList("c=one/d=two", "c=three/d=four")))
-            .thenReturn(Arrays.asList(existingPartition));
     existingReplicaTable.getParameters().put(REPLICATION_EVENT.parameterName(), "previousEventId");
     replica
         .updateMetadata(EVENT_ID, tableAndStatistics,
@@ -423,9 +419,6 @@ public class ReplicaTest {
   public void alteringExistingPartitionedReplicaViewSucceeds() throws Exception, IOException {
     convertSourceTableToView();
     convertExistingReplicaTableToView();
-    when(mockMetaStoreClient
-        .getPartitionsByNames(DB_NAME, TABLE_NAME, Lists.newArrayList("c=one/d=two", "c=three/d=four")))
-            .thenReturn(Arrays.asList(existingPartition));
     existingReplicaTable.getParameters().put(REPLICATION_EVENT.parameterName(), "previousEventId");
     replica
         .updateMetadata(EVENT_ID, tableAndStatistics,
@@ -512,8 +505,8 @@ public class ReplicaTest {
 
 
     List<String> testPartitionNames = new ArrayList<>();
-    for (Partition p : (List<Partition>) ListUtils.union(existingPartitions, newPartitions)) {
-      testPartitionNames.add(partitionName((String[]) p.getValues().toArray()));
+   for (Partition p : (List<Partition>) ListUtils.union(existingPartitions, newPartitions)) {
+      testPartitionNames.add(partitionName((String[]) p.getValues().toArray(new String[]{})));
     }
 
     when(mockMetaStoreClient.getPartitionsByNames(DB_NAME, TABLE_NAME, testPartitionNames))
@@ -550,7 +543,9 @@ public class ReplicaTest {
 
     verify(alterTableService).alterTable(eq(mockMetaStoreClient), eq(existingReplicaTable), any(Table.class));
     verify(mockMetaStoreClient).updateTableColumnStatistics(columnStatistics);
-    verify(mockReplicaLocationManager, times(numTestAlterPartitions)).addCleanUpLocation(anyString(), any(Path.class));
+    
+    verify(mockReplicaLocationManager, times(numTestAlterPartitions)).addCleanUpLocation(isNull(), any(Path.class));
+    
     verify(mockMetaStoreClient, times(numAlterBatches)).alter_partitions(eq(DB_NAME), eq(TABLE_NAME), alterPartitionCaptor.capture());
     verify(mockMetaStoreClient, times(numAddBatches)).add_partitions(addPartitionCaptor.capture());
 
@@ -692,7 +687,7 @@ public class ReplicaTest {
     verify(mockMetaStoreClient).updateTableColumnStatistics(columnStatistics);
     verify(mockMetaStoreClient).alter_partitions(eq(DB_NAME), eq(TABLE_NAME), alterPartitionCaptor.capture());
     verify(mockMetaStoreClient).add_partitions(addPartitionCaptor.capture());
-    verify(mockReplicaLocationManager, never()).addCleanUpLocation(anyString(), any(Path.class));
+    verify(mockReplicaLocationManager, never()).addCleanUpLocation(isNull(), any(Path.class));
 
     assertThat(alterPartitionCaptor.getValue().size(), is(1));
     assertThat(addPartitionCaptor.getValue().size(), is(1));

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/AlterTableServiceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/AlterTableServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica.hive;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/CopyPartitionsOperationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/CopyPartitionsOperationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica.hive;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/DropTableServiceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/DropTableServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica.hive;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.data.DataManipulator;
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/RenameTableOperationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/replica/hive/RenameTableOperationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.replica.hive;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/DestructiveSourceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/DestructiveSourceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.source;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/FilterMissingPartitionsLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/FilterMissingPartitionsLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.source;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/HdfsSnapshotLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/HdfsSnapshotLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.source;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.hotels.bdp.circustrain.core.source;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -63,20 +65,20 @@ public class SourceFactoryTest {
   @Test
   public void newInstanceMetadataMirrorReplicationModeOverridesDisabledSnapshots() throws Exception {
     when(tableReplication.getReplicationMode()).thenReturn(ReplicationMode.METADATA_MIRROR);
-    when(sourceCatalog.isDisableSnapshots()).thenReturn(false);
     SourceFactory sourceFactory = new SourceFactory(sourceCatalog, sourceHiveConf, sourceMetaStoreClientSupplier,
         sourceCatalogListener);
     Source source = sourceFactory.newInstance(tableReplication);
     assertTrue(source.isSnapshotsDisabled());
+    verify(sourceCatalog, never()).isDisableSnapshots();
   }
 
   @Test
   public void newInstanceMetadataUpdateReplicationModeOverridesDisabledSnapshots() throws Exception {
     when(tableReplication.getReplicationMode()).thenReturn(ReplicationMode.METADATA_UPDATE);
-    when(sourceCatalog.isDisableSnapshots()).thenReturn(false);
     SourceFactory sourceFactory = new SourceFactory(sourceCatalog, sourceHiveConf, sourceMetaStoreClientSupplier,
         sourceCatalogListener);
     Source source = sourceFactory.newInstance(tableReplication);
     assertTrue(source.isSnapshotsDisabled());
+    verify(sourceCatalog, never()).isDisableSnapshots();
   }
 }

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceFactoryTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceFactoryTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,9 +100,8 @@ public class SourceTest {
 
   @Before
   public void setupTable() {
-    when(metaStoreClientSupplier.get()).thenReturn(metaStoreClient);
     when(sourceCatalog.getName()).thenReturn(NAME);
-    when(sourceCatalog.isDisableSnapshots()).thenReturn(true);
+    //when(sourceCatalog.isDisableSnapshots()).thenReturn(true);
 
     table.setDbName(DATABASE);
     table.setTableName(TABLE);
@@ -146,6 +145,7 @@ public class SourceTest {
 
   @Test
   public void getTable() throws Exception {
+    when(metaStoreClientSupplier.get()).thenReturn(metaStoreClient);
     when(metaStoreClient.getTable(DATABASE, TABLE)).thenReturn(table);
     when(metaStoreClient.getTableColumnStatistics(DATABASE, TABLE, COLUMN_NAMES)).thenReturn(columnStatisticsObjs);
 
@@ -156,6 +156,7 @@ public class SourceTest {
 
   @Test
   public void getTableNoStats() throws Exception {
+    when(metaStoreClientSupplier.get()).thenReturn(metaStoreClient);
     when(metaStoreClient.getTable(DATABASE, TABLE)).thenReturn(table);
     when(metaStoreClient.getTableColumnStatistics(DATABASE, TABLE, COLUMN_NAMES))
         .thenReturn(Collections.<ColumnStatisticsObj> emptyList());
@@ -167,6 +168,7 @@ public class SourceTest {
 
   @Test
   public void getPartitions() throws Exception {
+    when(metaStoreClientSupplier.get()).thenReturn(metaStoreClient);
     when(metaStoreClient.listPartitionsByFilter(DATABASE, TABLE, PARTITION_PREDICATE, (short) MAX_PARTITIONS))
         .thenReturn(partitions);
     when(metaStoreClient.getPartitionColumnStatistics(DATABASE, TABLE, PARTITION_NAMES, COLUMN_NAMES))
@@ -179,6 +181,7 @@ public class SourceTest {
 
   @Test
   public void getPartitionsNoStats() throws Exception {
+    when(metaStoreClientSupplier.get()).thenReturn(metaStoreClient);
     when(metaStoreClient.listPartitionsByFilter(DATABASE, TABLE, PARTITION_PREDICATE, (short) MAX_PARTITIONS))
         .thenReturn(partitions);
     when(metaStoreClient.getPartitionColumnStatistics(DATABASE, TABLE, PARTITION_NAMES, COLUMN_NAMES))

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
@@ -17,8 +17,8 @@ package com.hotels.bdp.circustrain.core.source;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -45,7 +45,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/SourceTest.java
@@ -101,7 +101,6 @@ public class SourceTest {
   @Before
   public void setupTable() {
     when(sourceCatalog.getName()).thenReturn(NAME);
-    //when(sourceCatalog.isDisableSnapshots()).thenReturn(true);
 
     table.setDbName(DATABASE);
     table.setTableName(TABLE);

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/ViewLocationManagerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/source/ViewLocationManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package com.hotels.bdp.circustrain.core.source;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/CompositePartitionTransformationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/CompositePartitionTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.metadata.PartitionTransformation;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/CompositeTableTransformationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/CompositeTableTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.metadata.TableTransformation;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/TableParametersTransformationTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/transformation/TableParametersTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.core.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.conf.TransformOptions;
 import com.hotels.bdp.circustrain.api.event.EventTableReplication;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/util/MoreMapUtilsTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/core/util/MoreMapUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.core.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.core.util.MoreMapUtilsTest.MyEnum.ONE;
 import static com.hotels.bdp.circustrain.core.util.MoreMapUtilsTest.MyEnum.TWO_AND_A_HALF;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/extension/ExtensionInitializerTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/extension/ExtensionInitializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/extension/PropertyExtensionPackageProviderTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/extension/PropertyExtensionPackageProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.extension;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Iterator;
@@ -25,7 +25,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 import com.google.common.collect.ImmutableSet;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
@@ -39,7 +39,7 @@ import com.google.common.base.Preconditions;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ManifestAttributes.class })
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.sax.*", "org.w3c.dom.*"})
 public class ManifestAttributesTest {
 
   private @Rule final ClassDataFolder dataFolder = new ClassDataFolder();

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.manifest;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import java.net.URL;
 import java.security.CodeSource;
@@ -29,20 +29,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import fm.last.commons.test.file.ClassDataFolder;
 
 import com.google.common.base.Preconditions;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ ManifestAttributes.class })
-@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.sax.*", "org.w3c.dom.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class ManifestAttributesTest {
 
-  private @Rule final ClassDataFolder dataFolder = new ClassDataFolder();
+  public @Rule final ClassDataFolder dataFolder = new ClassDataFolder();
 
   public @Mock ClassLoader clazzLoader;
   public @Mock CodeSource clazzCodeSource;

--- a/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
+++ b/circus-train-core/src/test/java/com/hotels/bdp/circustrain/manifest/ManifestAttributesTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.manifest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;

--- a/circus-train-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/circus-train-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/circus-train-distcp-copier/pom.xml
+++ b/circus-train-distcp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-distcp-copier</artifactId>

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/CircusTrainCopyListingTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/CircusTrainCopyListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactoryTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.distcpcopier;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpOptionsParserTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/DistCpOptionsParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.distcpcopier;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.distcpcopier.DistCpOptionsParser.ATOMIC_COMMIT;
 import static com.hotels.bdp.circustrain.distcpcopier.DistCpOptionsParser.ATOMIC_WORK_PATH;

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/FileStatusTreeTraverserTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/FileStatusTreeTraverserTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.distcpcopier;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/HdfsDataManipulatorFactoryTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/HdfsDataManipulatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HdfsDataManipulatorFactoryTest {

--- a/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/RelativePathFunctionTest.java
+++ b/circus-train-distcp-copier/src/test/java/com/hotels/bdp/circustrain/distcpcopier/RelativePathFunctionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.distcpcopier;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 
 @RunWith(MockitoJUnitRunner.class)

--- a/circus-train-gcp/pom.xml
+++ b/circus-train-gcp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-gcp</artifactId>

--- a/circus-train-gcp/pom.xml
+++ b/circus-train-gcp/pom.xml
@@ -109,7 +109,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>fm.last.commons</groupId>

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/DistributedFileSystemPathProviderTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/DistributedFileSystemPathProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/DistributedFileSystemPathProviderTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/DistributedFileSystemPathProviderTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.gcp;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
 import org.apache.hadoop.conf.Configuration;
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.gcp.context.GCPSecurity;
 

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialCopierTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.gcp;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialCopierTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialCopierTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.gcp;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -32,7 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialPathProviderTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialPathProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package com.hotels.bdp.circustrain.gcp;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialPathProviderTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/GCPCredentialPathProviderTest.java
@@ -19,12 +19,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.gcp.context.GCPSecurity;
 

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/context/GCPBeanPostProcessorTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/context/GCPBeanPostProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/context/GCPBeanPostProcessorTest.java
+++ b/circus-train-gcp/src/test/java/com/hotels/bdp/circustrain/gcp/context/GCPBeanPostProcessorTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.context.CommonBeans;
 import com.hotels.bdp.circustrain.gcp.BindGoogleHadoopFileSystem;

--- a/circus-train-hive-view/pom.xml
+++ b/circus-train-hive-view/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive-view</artifactId>

--- a/circus-train-hive-view/pom.xml
+++ b/circus-train-hive-view/pom.xml
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/HqlTranslatorTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/HqlTranslatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,6 @@ public class HqlTranslatorTest {
   public void init() {
     when(sourceTable.getQualifiedName()).thenReturn(VIEW_NAME);
     when(tableReplication.getSourceTable()).thenReturn(sourceTable);
-    when(tableReplication.getReplicaTable()).thenReturn(replicaTable);
     List<TableReplication> tableReplicationList = ImmutableList
         .<TableReplication> builder()
         .add(tableReplication)

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/HqlTranslatorTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/HqlTranslatorTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.hive.view.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorIntegrationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorIntegrationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorIntegrationTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.hive.view.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableProcessorTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.hive.view.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableTranslationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableTranslationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableTranslationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/TableTranslationTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.hive.view.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/ViewTransformationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/ViewTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/ViewTransformationTest.java
+++ b/circus-train-hive-view/src/test/java/com/hotels/bdp/circustrain/hive/view/transformation/ViewTransformationTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.hive.view.transformation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-hive/pom.xml
+++ b/circus-train-hive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-hive</artifactId>

--- a/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/fetcher/BufferedPartitionFetcherTest.java
+++ b/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/fetcher/BufferedPartitionFetcherTest.java
@@ -15,8 +15,8 @@
  */
 package com.hotels.bdp.circustrain.hive.fetcher;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BufferedPartitionFetcherTest {

--- a/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/fetcher/BufferedPartitionFetcherTest.java
+++ b/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/fetcher/BufferedPartitionFetcherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -47,8 +46,7 @@ public class BufferedPartitionFetcherTest {
   private @Mock Partition p02;
   private @Mock Partition p03;
 
-  @Before
-  public void init() throws Exception {
+  private void init() throws Exception {
     when(p01.getValues()).thenReturn(Arrays.asList("01"));
     when(p02.getValues()).thenReturn(Arrays.asList("02"));
     when(p03.getValues()).thenReturn(Arrays.asList("03"));
@@ -63,9 +61,6 @@ public class BufferedPartitionFetcherTest {
 
   @Test(expected = PartitionNotFoundException.class)
   public void unknowPartition() throws Exception {
-    when(metastore.getPartitionsByNames(DATABASE_NAME, TABLE_NAME, Arrays.asList("a=01", "a=02", "a=03")))
-        .thenReturn(Arrays.asList(p01, p02, p03));
-
     BufferedPartitionFetcher fetcher = spy(new BufferedPartitionFetcher(metastore, table, (short) 10));
 
     fetcher.fetch("a=10");
@@ -73,6 +68,7 @@ public class BufferedPartitionFetcherTest {
 
   @Test
   public void all() throws Exception {
+    init();
     when(metastore.getPartitionsByNames(DATABASE_NAME, TABLE_NAME, Arrays.asList("a=01", "a=02", "a=03")))
         .thenReturn(Arrays.asList(p01, p02, p03));
 
@@ -85,6 +81,7 @@ public class BufferedPartitionFetcherTest {
 
   @Test
   public void longBuffer() throws Exception {
+    init();
     when(metastore.getPartitionsByNames(DATABASE_NAME, TABLE_NAME, Arrays.asList("a=01", "a=02", "a=03")))
         .thenReturn(Arrays.asList(p01, p02, p03));
 
@@ -97,6 +94,7 @@ public class BufferedPartitionFetcherTest {
 
   @Test
   public void shortBuffer() throws Exception {
+    init();
     when(metastore.getPartitionsByNames(DATABASE_NAME, TABLE_NAME, Arrays.asList("a=01", "a=02")))
         .thenReturn(Arrays.asList(p01, p02));
     when(metastore.getPartitionsByNames(DATABASE_NAME, TABLE_NAME, Arrays.asList("a=03")))

--- a/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/parser/HiveLanguageParserTest.java
+++ b/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/parser/HiveLanguageParserTest.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HiveLanguageParserTest {

--- a/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/parser/HiveLanguageParserTest.java
+++ b/circus-train-hive/src/test/java/com/hotels/bdp/circustrain/hive/parser/HiveLanguageParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.hotels.bdp.circustrain.hive.parser;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -25,7 +24,6 @@ import java.util.Stack;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.lib.NodeProcessor;
-import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -66,8 +64,7 @@ public class HiveLanguageParserTest {
   @Test
   public void typical() throws Exception {
     parser.parse(CREATE_TABLE_STATEMENT, nodeProcessor);
-    verify(nodeProcessor, times(49)).process(any(Node.class), any(Stack.class), any(NodeProcessorCtx.class),
-        anyVararg());
+    verify(nodeProcessor, times(49)).process(any(Node.class), any(Stack.class), any(), any());
   }
 
   @Test(expected = HiveParseException.class)

--- a/circus-train-housekeeping/pom.xml
+++ b/circus-train-housekeeping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-housekeeping</artifactId>

--- a/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/HousekeepingRunnerTest.java
+++ b/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/HousekeepingRunnerTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.housekeeping;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.metrics.MetricSender;
 import com.hotels.housekeeping.conf.Housekeeping;

--- a/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/HousekeepingRunnerTest.java
+++ b/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/HousekeepingRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.housekeeping;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;

--- a/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/JdbcHousekeepingListenerTest.java
+++ b/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/JdbcHousekeepingListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/JdbcHousekeepingListenerTest.java
+++ b/circus-train-housekeeping/src/test/java/com/hotels/bdp/circustrain/housekeeping/JdbcHousekeepingListenerTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.housekeeping;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.housekeeping.listener.JdbcHousekeepingListener;
 import com.hotels.housekeeping.model.LegacyReplicaPath;

--- a/circus-train-integration-tests/pom.xml
+++ b/circus-train-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-integration-tests</artifactId>

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsHdfsIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import static org.apache.hadoop.hive.metastore.MetaStoreUtils.isView;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainHdfsS3IntegrationTest.java
@@ -21,7 +21,7 @@ import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
 import static org.apache.hadoop.hive.metastore.MetaStoreUtils.isExternalTable;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.aws.AmazonS3URIs.toAmazonS3URI;

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainParquetSchemaEvolutionIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainParquetSchemaEvolutionIntegrationTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.integration;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.EVOLUTION_COLUMN;
 import static com.hotels.bdp.circustrain.integration.IntegrationTestHelper.PARTITIONED_TABLE;
@@ -125,6 +125,8 @@ public class CircusTrainParquetSchemaEvolutionIntegrationTest {
         "2\tafter\t2"
     );
     runTest(schema, evolvedSchema, new FieldDataWrapper(), afterEvolution);
+    //TODO: should we call runDataChecks here?
+    //runDataChecks(evolvedSchema, expectedData);
   }
 
   @Test
@@ -138,6 +140,8 @@ public class CircusTrainParquetSchemaEvolutionIntegrationTest {
         "2\t2"
     );
     runTest(schema, evolvedSchema, beforeEvolution, new FieldDataWrapper());
+  //TODO: should we call runDataChecks here?
+    //runDataChecks(evolvedSchema, expectedData);
   }
 
   // Replication success - old expectedData not "renamed" too

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainParquetSchemaEvolutionIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainParquetSchemaEvolutionIntegrationTest.java
@@ -125,8 +125,7 @@ public class CircusTrainParquetSchemaEvolutionIntegrationTest {
         "2\tafter\t2"
     );
     runTest(schema, evolvedSchema, new FieldDataWrapper(), afterEvolution);
-    //TODO: should we call runDataChecks here?
-    //runDataChecks(evolvedSchema, expectedData);
+    runDataChecks(evolvedSchema, expectedData);
   }
 
   @Test
@@ -140,8 +139,7 @@ public class CircusTrainParquetSchemaEvolutionIntegrationTest {
         "2\t2"
     );
     runTest(schema, evolvedSchema, beforeEvolution, new FieldDataWrapper());
-  //TODO: should we call runDataChecks here?
-    //runDataChecks(evolvedSchema, expectedData);
+    runDataChecks(evolvedSchema, expectedData);
   }
 
   // Replication success - old expectedData not "renamed" too

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainReplicationModeIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainReplicationModeIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainReplicationModeIntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainReplicationModeIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_MODE;

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
+++ b/circus-train-integration-tests/src/test/java/com/hotels/bdp/circustrain/integration/CircusTrainS3S3IntegrationTest.java
@@ -20,7 +20,7 @@ import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.api.CircusTrainTableParameter.REPLICATION_EVENT;
 import static com.hotels.bdp.circustrain.aws.AmazonS3URIs.toAmazonS3URI;

--- a/circus-train-metrics/pom.xml
+++ b/circus-train-metrics/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-metrics</artifactId>

--- a/circus-train-metrics/pom.xml
+++ b/circus-train-metrics/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -37,6 +39,12 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
 
     <!-- Java EL: needed for compatibility with new Spring and hibernate-validator -->

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/GraphiteMetricSenderTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/GraphiteMetricSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.graphite.GraphiteSender;

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/InetSocketAddressFactoryTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/InetSocketAddressFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.metrics;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.InetSocketAddress;
 

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/JobCounterGaugeTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/JobCounterGaugeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.metrics;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JobCounterGaugeTest {

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/JobMetricsTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/JobMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.metrics;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +28,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteLoaderTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteLoaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.metrics.conf;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.metrics.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Set;
 

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorIntegrationTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.metrics.conf;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class GraphiteValidatorTest {
 
   @Before
   public void before() {
-    when(loader.load(any(Path.class))).thenReturn(loaded);
+    when(loader.load(any())).thenReturn(loaded);
 
     validator = new GraphiteValidator(loader);
   }

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/GraphiteValidatorTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.metrics.conf;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
 

--- a/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/MetricsConfTest.java
+++ b/circus-train-metrics/src/test/java/com/hotels/bdp/circustrain/metrics/conf/MetricsConfTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.MetricRegistry;
 

--- a/circus-train-package/pom.xml
+++ b/circus-train-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/pom.xml
+++ b/circus-train-s3-mapreduce-cp-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp-copier</artifactId>

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierFactoryTest.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.MetricRegistry;
 

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpCopierTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.s3mapreducecpcopier;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.verify;
@@ -55,7 +55,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
+++ b/circus-train-s3-mapreduce-cp-copier/src/test/java/com/hotels/bdp/circustrain/s3mapreducecpcopier/S3MapReduceCpOptionsParserTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.s3mapreducecpcopier;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.CANNED_ACL;
 import static com.hotels.bdp.circustrain.s3mapreducecpcopier.S3MapReduceCpOptionsParser.COPY_STRATEGY;

--- a/circus-train-s3-mapreduce-cp/pom.xml
+++ b/circus-train-s3-mapreduce-cp/pom.xml
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/circus-train-s3-mapreduce-cp/pom.xml
+++ b/circus-train-s3-mapreduce-cp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-mapreduce-cp</artifactId>

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/CopyListingTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/CopyListingTest.java
@@ -21,7 +21,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.util.Arrays;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/OptionsParserTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/OptionsParserTest.java
@@ -21,7 +21,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.util.Arrays;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/S3MapReduceCpOptionsTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.util.Arrays;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/SimpleCopyListingTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/SimpleCopyListingTest.java
@@ -22,7 +22,7 @@
 package com.hotels.bdp.circustrain.s3mapreducecp;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsS3ClientFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsS3ClientFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsS3ClientFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsS3ClientFactoryTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp.aws;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsUtilTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsUtilTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/AwsUtilTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp.aws;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/CounterBasedRetryConditionTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/CounterBasedRetryConditionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/CounterBasedRetryConditionTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/CounterBasedRetryConditionTest.java
@@ -16,12 +16,12 @@
 package com.hotels.bdp.circustrain.s3mapreducecp.aws;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonWebServiceRequest;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/ExponentialBackoffStrategyTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/ExponentialBackoffStrategyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/ExponentialBackoffStrategyTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/ExponentialBackoffStrategyTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.s3mapreducecp.aws;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.mockito.Mock;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/S3MapreduceDataManipulatorFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/S3MapreduceDataManipulatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/S3MapreduceDataManipulatorFactoryTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/aws/S3MapreduceDataManipulatorFactoryTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class S3MapreduceDataManipulatorFactoryTest {

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/io/BytesFormatterTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/io/BytesFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/io/BytesFormatterTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/io/BytesFormatterTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.s3mapreducecp.io;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PathConverterTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PathConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PathConverterTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/jcommander/PathConverterTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.s3mapreducecp.jcommander;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/ConfigurationUtilTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/ConfigurationUtilTest.java
@@ -20,7 +20,7 @@
 package com.hotels.bdp.circustrain.s3mapreducecp.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.List;

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/IoUtilTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/IoUtilTest.java
@@ -30,7 +30,7 @@ import java.io.Closeable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/PathUtilTest.java
+++ b/circus-train-s3-mapreduce-cp/src/test/java/com/hotels/bdp/circustrain/s3mapreducecp/util/PathUtilTest.java
@@ -21,7 +21,7 @@ package com.hotels.bdp.circustrain.s3mapreducecp.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 

--- a/circus-train-s3-s3-copier/pom.xml
+++ b/circus-train-s3-s3-copier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-s3-s3-copier</artifactId>

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.hotels.bdp.circustrain.s3s3copier;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 
 import java.net.URI;
 import java.util.HashMap;

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierOptionsTest.java
@@ -17,7 +17,7 @@ package com.hotels.bdp.circustrain.s3s3copier;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.util.HashMap;

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
@@ -17,8 +17,8 @@ package com.hotels.bdp.circustrain.s3s3copier;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.circustrain.s3s3copier;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -432,11 +432,9 @@ public class S3S3CopierTest {
     TransferManager mockedTransferManager = Mockito.mock(TransferManager.class);
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
-    Copy copy = Mockito.mock(Copy.class);
     when(mockedTransferManager
         .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
             .thenThrow(new AmazonClientException("S3 error"));
-    TransferProgress transferProgress = new TransferProgress();
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
         mockedTransferManagerFactory, listObjectsRequestFactory, registry, s3S3CopierOptions);
     try {

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/S3S3CopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,7 +315,6 @@ public class S3S3CopierTest {
     when(mockedTransferManagerFactory.newInstance(any(AmazonS3.class), eq(s3S3CopierOptions)))
         .thenReturn(mockedTransferManager);
     Copy copy = Mockito.mock(Copy.class);
-    when(copy.getProgress()).thenReturn(new TransferProgress());
     when(mockedTransferManager
         .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
             .thenReturn(copy);
@@ -438,7 +437,6 @@ public class S3S3CopierTest {
         .copy(any(CopyObjectRequest.class), any(AmazonS3.class), any(TransferStateChangeListener.class)))
             .thenThrow(new AmazonClientException("S3 error"));
     TransferProgress transferProgress = new TransferProgress();
-    when(copy.getProgress()).thenReturn(transferProgress);
     S3S3Copier s3s3Copier = new S3S3Copier(sourceBaseLocation, sourceSubLocations, replicaLocation, s3ClientFactory,
         mockedTransferManagerFactory, listObjectsRequestFactory, registry, s3S3CopierOptions);
     try {

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/S3DataManipulatorFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/S3DataManipulatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/S3DataManipulatorFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/S3DataManipulatorFactoryTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class S3DataManipulatorFactoryTest {

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/TransferManagerFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/TransferManagerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/TransferManagerFactoryTest.java
+++ b/circus-train-s3-s3-copier/src/test/java/com/hotels/bdp/circustrain/s3s3copier/aws/TransferManagerFactoryTest.java
@@ -16,14 +16,14 @@
 package com.hotels.bdp.circustrain.s3s3copier.aws;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.transfer.TransferManager;

--- a/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-comparison-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-comparison-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-comparison-tool/src/test/java/com/hotels/bdp/circustrain/tool/comparison/ComparisonToolIntegrationTest.java
+++ b/circus-train-tool-parent/circus-train-comparison-tool/src/test/java/com/hotels/bdp/circustrain/tool/comparison/ComparisonToolIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-tool-parent/circus-train-comparison-tool/src/test/java/com/hotels/bdp/circustrain/tool/comparison/ComparisonToolIntegrationTest.java
+++ b/circus-train-tool-parent/circus-train-comparison-tool/src/test/java/com/hotels/bdp/circustrain/tool/comparison/ComparisonToolIntegrationTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.tool.comparison;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/circus-train-tool-parent/circus-train-filter-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-filter-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-filter-tool</artifactId>

--- a/circus-train-tool-parent/circus-train-filter-tool/src/test/java/com/hotels/bdp/circustrain/tool/filter/FilterToolIntegrationTest.java
+++ b/circus-train-tool-parent/circus-train-filter-tool/src/test/java/com/hotels/bdp/circustrain/tool/filter/FilterToolIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-tool-parent/circus-train-filter-tool/src/test/java/com/hotels/bdp/circustrain/tool/filter/FilterToolIntegrationTest.java
+++ b/circus-train-tool-parent/circus-train-filter-tool/src/test/java/com/hotels/bdp/circustrain/tool/filter/FilterToolIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_CONNECTION
 import static org.apache.hadoop.mapreduce.MRConfig.FRAMEWORK_NAME;
 import static org.apache.hadoop.mapreduce.MRConfig.LOCAL_FRAMEWORK_NAME;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/circus-train-tool-parent/circus-train-tool-core/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-core</artifactId>

--- a/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/ReplicaHiveEndpointTest.java
+++ b/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/ReplicaHiveEndpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/ReplicaHiveEndpointTest.java
+++ b/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/ReplicaHiveEndpointTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.tool.core.endpoint;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/SourceHiveEndpointTest.java
+++ b/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/SourceHiveEndpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/SourceHiveEndpointTest.java
+++ b/circus-train-tool-parent/circus-train-tool-core/src/test/java/com/hotels/bdp/circustrain/tool/core/endpoint/SourceHiveEndpointTest.java
@@ -16,7 +16,7 @@
 package com.hotels.bdp.circustrain.tool.core.endpoint;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Supplier;
 

--- a/circus-train-tool-parent/circus-train-tool/pom.xml
+++ b/circus-train-tool-parent/circus-train-tool/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-tool-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool</artifactId>

--- a/circus-train-tool-parent/pom.xml
+++ b/circus-train-tool-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>circus-train-parent</artifactId>
-    <version>16.3.4-SNAPSHOT</version>
+    <version>16.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-tool-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>5.0.0</version>
+    <version>6.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>circus-train-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>circus-train-parent</artifactId>
   <description>circus-train replicates data and hive metadata between various clusters</description>
-  <version>16.3.4-SNAPSHOT</version>
+  <version>16.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Circus Train Parent</name>
   <inceptionYear>2016</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -56,9 +58,9 @@
     <!-- END: AWS jdk version + dependencies -->
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.7</hive.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.28.2</mockito.version>
     <junit.version>4.13.1</junit.version>
-    <powermock.version>1.6.4</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <derby.version>10.10.2.0</derby.version>
     <beeju.version>3.3.0</beeju.version>
     <hamcrest-library.version>1.3</hamcrest-library.version>
@@ -121,6 +123,12 @@
         <artifactId>hive-metastore</artifactId>
         <version>${hive.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
@@ -192,12 +200,12 @@
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
-      </dependency>
+<!--       <dependency> -->
+<!--         <groupId>org.mockito</groupId> -->
+<!--         <artifactId>mockito-all</artifactId> -->
+<!--         <version>${mockito.version}</version> -->
+<!--         <scope>test</scope> -->
+<!--       </dependency> -->
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
@@ -218,7 +226,7 @@
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
+        <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,12 +200,6 @@
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
-<!--       <dependency> -->
-<!--         <groupId>org.mockito</groupId> -->
-<!--         <artifactId>mockito-all</artifactId> -->
-<!--         <version>${mockito.version}</version> -->
-<!--         <scope>test</scope> -->
-<!--       </dependency> -->
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>6.2.1-SNAPSHOT</version>
+    <version>6.2.1</version>
   </parent>
 
   <artifactId>circus-train-parent</artifactId>


### PR DESCRIPTION
This PR covers a number of changes required to get Circus Train building successfully using Java 11, as well as some cleanup and improvements, here's a summary of the changes:

* Add explicit imports on libraries no longer present in Java 11 (`javax.annotation-api`, `jaxb-api`).
* Exclude dependencies on `jdk.tools` as this is no longer present in Java 11.
* Removed some usages of `powermock` which didn't play nicely with Java 11.
* Upgrade to latest 2.x versions of Mockito and PowerMock for Java 11 support.
* Proactively move to non-deprecated code in JUnit, Mockito and Hamcrest (brought to you by `sed` and `grep`).
* Run GitHub actions using Java 8 and 11 to prove that both work (and to prevent regressions).
* Remove unnecessary Mockito stubbings (version of Mockito that supports Java 11 by default fails tests on these).
* Fixed Javadoc warnings in `circus-train-api` module.